### PR TITLE
docs(engineering-backend-architect): update skill description and README for broader agent use

### DIFF
--- a/skills/engineering/engineering-backend-architect/README.md
+++ b/skills/engineering/engineering-backend-architect/README.md
@@ -1,6 +1,6 @@
 # Engineering Backend Architect
 
-This is a standalone Codex skill for backend architecture design and review.
+This is a standalone skill for backend architecture design and review.
 
 It is intended for requests such as:
 
@@ -11,12 +11,12 @@ It is intended for requests such as:
 
 ## Files
 
-- `SKILL.md`: Agent-facing instructions, workflow, output template, and decision rules
-- `agents/openai.yaml`: UI metadata for skill display and invocation
+- `SKILL.md`: Core skill instructions, workflow, output template, and decision rules
+- `agents/openai.yaml`: Optional metadata for Codex/OpenAI-compatible tooling and UI integration
 
 ## What This Skill Does
 
-The skill guides Codex to:
+The skill guides an agent or assistant to:
 
 - frame backend requirements and assumptions
 - choose an architecture shape with explicit tradeoffs
@@ -30,7 +30,7 @@ It intentionally prefers concrete tradeoffs over generic architecture slogans, a
 ## Notes
 
 - This skill is written to operate independently. It does not require the original document to be usable.
-- The content was restructured for Codex execution, with a stronger emphasis on workflow, output shape, and triggerability.
+- The core skill is tool-agnostic. Files such as `agents/openai.yaml` are additive support for specific ecosystems and are not required to use the skill.
 
 ## Source Attribution
 

--- a/skills/engineering/engineering-backend-architect/SKILL.md
+++ b/skills/engineering/engineering-backend-architect/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: engineering-backend-architect
-description: Design backend system architecture for new products, large features, platform refactors, API and database design, microservices decomposition, event-driven systems, scaling, reliability, observability, and cloud deployment. Use when Codex needs to act as a senior backend architect to define service boundaries, data models, security controls, performance strategy, or technical tradeoffs for server-side systems.
+description: Design backend system architecture for new products, large features, platform refactors, API and database design, microservices decomposition, event-driven systems, scaling, reliability, observability, and cloud deployment. Use when an agent or assistant needs to act as a senior backend architect to define service boundaries, data models, security controls, performance strategy, or technical tradeoffs for server-side systems.
 ---
 
 # Engineering Backend Architect
 
-Provide a practical backend architecture workflow for Codex.
+Provide a practical backend architecture workflow for a general-purpose agent or assistant.
 
 ## Operating Mode
 


### PR DESCRIPTION
- Changed references from Codex-specific to general agent or assistant
- Clarified skill metadata role as optional support for specific ecosystems
- Updated README to emphasize tool-agnostic nature of the core skill
- Revised SKILL.md description to reflect general-purpose backend architecture guidance
- Improved wording for better clarity and inclusiveness of agent types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded backend architect skill documentation with clearer guidance on service boundaries, data models, security, and deployment planning.
  * Broadened skill applicability to work with various agents and assistants.
  * Enhanced emphasis on concrete tradeoffs and minimal viable architecture.
  * Added source attribution for transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->