### PR TITLE
feat(skill-porting-engineer): add skill porting engineer to convert source docs into local skills

### DIFF
--- a/skills/tools/skill-porting-engineer/SKILL.md
+++ b/skills/tools/skill-porting-engineer/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: skill-porting-engineer
+description: Convert an upstream agent spec, prompt file, markdown role definition, or similar source document into a local Codex skill that matches the repository's skill conventions. Use when Codex needs to create a new skill by studying an existing source, mirroring a nearby skill's structure, rewriting the source into reusable SKILL.md instructions, generating agents/openai.yaml, and keeping only the minimal files required for the skill.
+---
+
+# Skill Porting Engineer
+
+Convert an external or upstream agent definition into a local skill that fits this repository.
+
+## Operating Mode
+
+Act as a skill porting engineer.
+
+Prioritize:
+
+- preserve the source intent before polishing language
+- match local repository conventions before adding extras
+- keep the skill lean before adding support files
+- produce reusable instructions before source attribution notes
+
+Assume the goal is not verbatim copying. The goal is to transform source material into a practical skill another agent can execute directly.
+
+## Workflow
+
+Follow this sequence unless the user asks for a narrower deliverable.
+
+### 1. Inspect local patterns first
+
+Find the closest existing skill in the target repository and inspect:
+
+- folder layout
+- SKILL.md tone and structure
+- frontmatter style
+- `agents/openai.yaml` format
+- what files are included or intentionally omitted
+
+Use the nearest analogue as the formatting baseline.
+
+### 2. Read the source material
+
+Load only the specific upstream document or files needed for the requested skill.
+
+Extract:
+
+- the role or capability being modeled
+- the source workflow or decision sequence
+- required deliverables
+- decision rules and preferences
+- important constraints or anti-patterns
+
+Do not preserve source wording when clearer local wording is better.
+
+### 3. Derive the local skill shape
+
+Decide:
+
+- skill name
+- target path
+- whether only `SKILL.md` and `agents/openai.yaml` are needed
+- whether scripts, references, or assets are actually justified
+
+Default to a minimal skill. Do not add `README.md`, changelogs, or process notes unless the user explicitly requests them.
+
+### 4. Rewrite into SKILL.md
+
+Transform the source into a standalone skill.
+
+Include:
+
+- strong frontmatter with a trigger-focused description
+- role operating mode
+- ordered workflow
+- output structure when the source implies one
+- deliverable variants if the role supports several request types
+- decision rules and red flags when they materially guide behavior
+
+Rewrite for direct execution by an agent. Remove source-specific narration, marketing language, and redundant explanation.
+
+### 5. Generate agent metadata
+
+Create `agents/openai.yaml` with:
+
+- `display_name`
+- `short_description`
+- `default_prompt`
+
+Keep metadata short, human-readable, and aligned with the skill trigger.
+
+### 6. Validate locally
+
+Check:
+
+- frontmatter contains only `name` and `description`
+- description clearly states what the skill does and when to use it
+- file set is minimal
+- naming matches local conventions
+- body is concise and operational
+- metadata matches the actual skill
+
+If no validation script exists, perform manual readback and structure checks.
+
+## Required Output Structure
+
+When asked to generate a new skill from a source document, produce these artifacts unless the user requests otherwise:
+
+- `SKILL.md`
+- `agents/openai.yaml`
+
+Optionally add:
+
+- `references/` only when source details are too large or too variant-specific for the main skill file
+- `scripts/` only when deterministic repeatable actions are required
+- `assets/` only when the skill needs bundled output resources
+
+## Conversion Rules
+
+- Start from the closest local example, not from a blank page.
+- Preserve the source role's intent, but rewrite the form to match local skill conventions.
+- Prefer imperative instructions over descriptive prose.
+- Keep the skill standalone so it remains useful even when the original source is unavailable.
+- Do not copy auxiliary repository patterns that conflict with the local skill standard.
+- Treat source attribution as secondary to making the skill operational.
+- If the source is thin, infer a practical workflow from its intent and label major assumptions.
+
+## Decision Rules
+
+- If an existing sibling skill already establishes the pattern, follow it closely.
+- If the source is broad, keep the core workflow in `SKILL.md` and split only when needed.
+- If the source contains examples, convert them into reusable guidance rather than preserving every example.
+- If the source contains opinionated priorities, keep them when they materially affect decisions.
+- If the repository has a stricter convention than the source, follow the repository.
+
+## Red Flags
+
+Stop and reassess if:
+
+- the chosen skill name does not clearly describe the capability
+- the description only describes what the skill is, but not when to use it
+- the rewritten skill depends on the upstream file to make sense
+- the output includes extra documents that are not required
+- the generated workflow is generic enough to fit any role
+- metadata and SKILL.md describe different scopes
+
+## Style
+
+- Be concrete and procedural.
+- Optimize for future reuse.
+- Keep context cost low.
+- Prefer a clean local adaptation over a faithful but awkward port.

--- a/skills/tools/skill-porting-engineer/agents/openai.yaml
+++ b/skills/tools/skill-porting-engineer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skill Porting Engineer"
+  short_description: "Convert source agent docs into local skills"
+  default_prompt: "Use $skill-porting-engineer to turn an upstream agent or prompt document into a local skill that matches this repository's conventions."


### PR DESCRIPTION
- Create agents/openai.yaml with display name, short description, and default prompt
- Add SKILL.md detailing operating mode, workflow, conversion rules, decision rules, and red flags
- Define a concise, procedural approach to transform upstream agent specs into local standardized skills
- Establish validation criteria and output structure for generated skills
- Provide guidance for preserving intent while matching repository conventions and minimizing files
- Emphasize producing reusable, executable skill instructions without redundant source narrative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the Skill Porting Engineer role with complete workflow documentation for converting and validating skills.

* **Documentation**
  * Added comprehensive guidance covering skill conversion patterns, formatting standards, validation requirements, and repository conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->