### PR TITLE
feat(github-create-pr): add local skill for drafting and creating GitHub PRs

### DIFF
--- a/skills/github/github-create-pr/README.md
+++ b/skills/github/github-create-pr/README.md
@@ -1,0 +1,37 @@
+# github-create-pr
+
+Local Codex skill for preparing and creating GitHub pull requests.
+
+## Scope
+
+- Check branch status and PR base
+- Analyze commits and diff
+- Draft a clear PR title and body
+- Create or update a PR with `gh`
+- Add reviewers when needed
+
+## Structure
+
+```text
+github-create-pr/
+├── SKILL.md
+├── README.md
+└── agents/
+    └── openai.yaml
+```
+
+## Source Attribution
+
+This skill is a localized adaptation of the following upstream skill:
+
+- Source: `getsentry/skills`
+- Upstream path: `plugins/sentry-skills/skills/pr-writer/SKILL.md`
+- URL: <https://github.com/getsentry/skills/blob/main/plugins/sentry-skills/skills/pr-writer/SKILL.md>
+
+## Notes
+
+This version is not a verbatim copy of the upstream content. It was rewritten to match this repository's local skill conventions:
+
+- The skill name was changed to `github-create-pr`
+- Sentry-specific language was generalized into a GitHub PR workflow
+- The output structure and metadata were adapted to the local Codex skill format

--- a/skills/github/github-create-pr/SKILL.md
+++ b/skills/github/github-create-pr/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: github-create-pr
+description: Create GitHub pull requests from a local branch using a reviewable workflow for branch checks, diff analysis, PR title/body writing, and gh CLI creation. Use when opening a PR, drafting or improving a PR description, preparing a branch for review, or adding reviewers on GitHub.
+---
+
+# GitHub Create PR
+
+Create GitHub pull requests with a clear, reviewable workflow.
+
+## Operating Mode
+
+Act as a pragmatic PR writer and GitHub workflow assistant.
+
+Prioritize:
+
+- branch hygiene before PR creation
+- clear reviewer context before exhaustive detail
+- concise PR bodies over diff narration
+- repository conventions over generic defaults
+
+Assume `gh` is installed and authenticated unless local evidence shows otherwise.
+
+## Workflow
+
+Follow this sequence unless the user asks for only one part of the PR process.
+
+### 1. Verify branch readiness
+
+Check:
+
+- current branch
+- working tree status
+- base branch
+- commits that will be included
+
+Use commands such as:
+
+```bash
+git status
+git branch --show-current
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+git log <base>..HEAD --oneline
+```
+
+If there are uncommitted changes that should be part of the PR, stop PR creation and handle commits first.
+
+If the branch is stale or diverged, call that out and recommend rebasing or merging before opening the PR.
+
+### 2. Analyze the change set
+
+Review the commits and full diff that will land in the PR.
+
+Use commands such as:
+
+```bash
+git log <base>..HEAD
+git diff <base>...HEAD
+```
+
+Extract:
+
+- what changed
+- why it changed
+- user or system impact
+- risks, migrations, or rollout notes
+- any issue references already implied by commits or branch naming
+
+Do not write the PR body until the scope is understood.
+
+### 3. Write the PR title
+
+Prefer a short, searchable title that matches the repository's existing convention.
+
+If the repository uses conventional-commit style titles, follow that pattern:
+
+- `feat(scope): add token refresh`
+- `fix(api): handle null response`
+- `refactor(auth): extract validation logic`
+
+If no convention is visible, use a plain imperative summary.
+
+### 4. Write the PR body
+
+Default to a compact structure:
+
+```markdown
+<what this PR does>
+
+<why these changes are needed>
+
+<important implementation notes, tradeoffs, or reviewer context>
+
+<issue references if relevant>
+```
+
+Include:
+
+- what changed
+- why now
+- context not obvious from the code
+- links or references to issues, tickets, or incidents
+- reviewer guidance only when it helps focus attention
+
+Avoid:
+
+- test-plan boilerplate unless the repository clearly expects it
+- checkbox cargo-cult sections
+- line-by-line diff summaries
+- vague claims like "small cleanup" when behavior actually changed
+
+### 5. Create or update the PR
+
+For a new PR, prefer `gh pr create` with explicit title and body:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Use `--draft` when the branch is intentionally not ready for full review.
+
+For an existing PR, use `gh pr edit` to update the title, body, or reviewers.
+
+### 6. Add reviewers deliberately
+
+Keep reviewer count focused. Prefer the smallest set of relevant reviewers.
+
+Use commands such as:
+
+```bash
+gh pr edit --add-reviewer username1,username2
+gh pr edit --add-reviewer org/team-name
+```
+
+If the user does not specify reviewers, infer likely owners only from clear local evidence such as CODEOWNERS or recent authorship. Otherwise leave reviewers unset.
+
+## Output Structure
+
+When the user asks for help writing a PR, provide:
+
+```markdown
+# PR Draft
+
+## Title
+<proposed PR title>
+
+## Body
+<proposed PR body>
+
+## Notes
+- branch readiness concerns
+- missing context or blockers
+- suggested `gh` command if useful
+```
+
+If the user asks to open the PR directly, still summarize the final title, body, and any assumptions after running the command.
+
+## Decision Rules
+
+- Follow repository-specific PR templates or title conventions when present.
+- Prefer draft PRs when work is incomplete, risky, or waiting on feedback.
+- Keep one PR focused on one coherent change set; call out unrelated changes if found.
+- Explain behavior changes, migrations, and follow-up work explicitly.
+- Use issue-closing syntax only when the linkage is clear and intended.
+
+## Red Flags
+
+Stop and reassess if:
+
+- the working tree is dirty in a way that makes PR scope ambiguous
+- the branch contains unrelated commits
+- the diff is too large to describe honestly as one reviewable unit
+- the requested PR body conflicts with visible repository conventions
+- the user asks to create a PR without enough context to describe the change accurately

--- a/skills/github/github-create-pr/agents/openai.yaml
+++ b/skills/github/github-create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Create PR"
+  short_description: "Draft and open reviewable GitHub pull requests"
+  default_prompt: "Use $github-create-pr to prepare a branch for review, draft a strong PR title and body, and create or update the GitHub pull request with gh."


### PR DESCRIPTION
Add a new local Codex skill, `github-create-pr`, for preparing and creating GitHub pull requests.

This change ports the upstream `pr-writer` skill from `getsentry/skills` into the local skill layout used by this repository. The new skill covers branch readiness checks,
diff analysis, PR title/body drafting, `gh`-based PR creation, and reviewer handling.

It also includes:
- local `agents/openai.yaml` metadata for UI integration
- an English `README.md` with source attribution to the upstream skill
- localized instructions rewritten to fit this repository's skill conventions instead of copying the upstream file verbatim

This PR adds a focused GitHub PR workflow skill under `skills/github/github-create-pr` and keeps the file set minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new GitHub Pull Request creation agent that guides users through drafting PR titles and descriptions, creating or updating pull requests, and managing reviewer assignments via GitHub CLI integration.

* **Documentation**
  * Added comprehensive workflow documentation for the PR creation agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->