### PR TITLE
feat(skill-porting-engineer): tighten neutrality and attribution rules

### DIFF
--- a/skills/tools/skill-porting-engineer/SKILL.md
+++ b/skills/tools/skill-porting-engineer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: skill-porting-engineer
-description: Convert an upstream agent spec, prompt file, markdown role definition, or similar source document into a local Codex skill that matches the repository's skill conventions.
+description: Convert an upstream agent spec, prompt file, markdown role definition, or similar source document into a local skill that matches the target repository's conventions. Use when porting an external agent or prompt into this repository's skill format, adapting an existing role definition into reusable local instructions, or auditing whether an imported skill matches local structure, triggering, and packaging rules.
 ---
 
 # Skill Porting Engineer
 
-Convert an external or upstream agent definition into a local skill that fits this repository.
+Convert an external or upstream agent definition into a local skill that fits the target repository.
 
 ## Operating Mode
 
@@ -19,6 +19,8 @@ Prioritize:
 - produce reusable instructions before source attribution notes
 
 Assume the goal is not verbatim copying. The goal is to transform source material into a practical skill another agent can execute directly.
+
+Treat the source capability as the core artifact. Treat repository-specific packaging as an adaptation layer, not the essence of the skill.
 
 ## Workflow
 
@@ -50,18 +52,29 @@ Extract:
 
 Do not preserve source wording when clearer local wording is better.
 
-### 3. Derive the local skill shape
+### 3. Separate neutral capability from local adaptation
+
+Before writing, split the source into two layers:
+
+- neutral core: role, workflow, decision rules, deliverables, constraints, and anti-patterns that would still make sense outside this repository
+- local adaptation: file layout, metadata fields, path conventions, validation steps, and any repository-specific packaging requirements
+
+Keep the neutral core dominant. Add local adaptation only where it is needed to make the skill usable in this repository.
+
+### 4. Derive the local skill shape
 
 Decide:
 
 - skill name
 - target path
-- whether only `SKILL.md` and `agents/openai.yaml` are needed
+- whether `SKILL.md`, `agents/openai.yaml`, and `README.md` are sufficient
 - whether scripts, references, or assets are actually justified
 
-Default to a minimal skill. Do not add `README.md`, changelogs, or process notes unless the user explicitly requests them.
+Default to a minimal skill. Include `README.md` as the human-facing companion document. Do not add changelogs or process notes unless the user explicitly requests them.
 
-### 4. Rewrite into SKILL.md
+If the source references tools, files, or workflows that do not exist locally, translate them into local equivalents or omit them.
+
+### 5. Rewrite into SKILL.md
 
 Transform the source into a standalone skill.
 
@@ -76,7 +89,9 @@ Include:
 
 Rewrite for direct execution by an agent. Remove source-specific narration, marketing language, and redundant explanation.
 
-### 5. Generate agent metadata
+Favor wording that stays valid if the same skill is later ported to another agent system. Mention repository-specific files only where they are operationally required.
+
+### 6. Generate repository metadata
 
 Create `agents/openai.yaml` with:
 
@@ -86,7 +101,24 @@ Create `agents/openai.yaml` with:
 
 Keep metadata short, human-readable, and aligned with the skill trigger.
 
-### 6. Validate locally
+Treat metadata as an interface adapter for this repository, not as the core definition of the skill.
+
+### 7. Add README and attribution notes
+
+Create a concise `README.md` for human readers.
+
+Include:
+
+- what the skill does
+- the main files it contains
+- how it should be used at a high level
+- any important setup, assumptions, or scope boundaries
+
+If the skill was derived from third-party material, add a source or attribution section that records the original work, author or publisher when known, and the source location.
+
+Treat attribution as a respect requirement for upstream authors, even when the skill body itself is heavily rewritten.
+
+### 8. Validate locally
 
 Check:
 
@@ -96,8 +128,36 @@ Check:
 - naming matches local conventions
 - body is concise and operational
 - metadata matches the actual skill
+- `README.md` exists and accurately summarizes the skill for human readers
+- third-party sources are attributed when upstream material was used
+- the core workflow still makes sense without repository-specific metadata
+- repository-specific instructions do not overwhelm the neutral skill logic
 
 If no validation script exists, perform manual readback and structure checks.
+
+### 9. Audit with a skill-creation specialist when available
+
+After the first complete draft is ready, run a second-pass audit with a skill-creation specialist if the target environment provides one such as `$skill-creator`.
+
+Use that audit to:
+
+- check whether the trigger description is specific enough
+- identify missing reusable resources or unnecessary files
+- tighten wording, structure, and progressive disclosure
+- improve neutrality, portability, and packaging discipline
+
+Treat this as optimization and quality control, not as a license to expand scope without justification.
+
+### 10. Smoke-test the port
+
+Test the rewritten skill against one or two realistic prompts.
+
+Confirm:
+
+- the frontmatter would trigger for those prompts
+- the body gives a specific enough workflow to execute
+- the skill remains understandable even if repository-specific metadata is ignored
+- optional files are justified by repeated use, not habit
 
 ## Required Output Structure
 
@@ -105,6 +165,7 @@ When asked to generate a new skill from a source document, produce these artifac
 
 - `SKILL.md`
 - `agents/openai.yaml`
+- `README.md`
 
 Optionally add:
 
@@ -116,10 +177,15 @@ Optionally add:
 
 - Start from the closest local example, not from a blank page.
 - Preserve the source role's intent, but rewrite the form to match local skill conventions.
+- Keep the capability description neutral; localize packaging, not the underlying role.
+- Keep the skill portable across agent platforms when possible. Platform-specific behavior from Codex, Claude Code, or similar systems should be framed as optional augmentation, not as the core capability.
 - Prefer imperative instructions over descriptive prose.
+- Convert repository-specific source references into generic operational guidance first, then adapt them back into local files if needed.
 - Keep the skill standalone so it remains useful even when the original source is unavailable.
+- Add a human-facing `README.md` for orientation, usage, and source notes.
+- Preserve and document upstream attribution when third-party material materially informed the skill.
 - Do not copy auxiliary repository patterns that conflict with the local skill standard.
-- Treat source attribution as secondary to making the skill operational.
+- Treat source attribution as a required part of a complete port whenever third-party material informed the result.
 - If the source is thin, infer a practical workflow from its intent and label major assumptions.
 
 ## Decision Rules
@@ -129,6 +195,10 @@ Optionally add:
 - If the source contains examples, convert them into reusable guidance rather than preserving every example.
 - If the source contains opinionated priorities, keep them when they materially affect decisions.
 - If the repository has a stricter convention than the source, follow the repository.
+- If local metadata or file conventions force awkward wording, keep the core instructions clean and confine the adaptation to the packaging layer.
+- If an existing local skill is already overfit to one agent platform, remove platform-centric claims unless they are required by the repository interface.
+- If platform-specific guidance is useful, isolate it as an additive layer so the main workflow still works for other model environments.
+- If third-party source material was used, record attribution in `README.md` even when the implementation is substantially adapted.
 
 ## Red Flags
 
@@ -140,6 +210,11 @@ Stop and reassess if:
 - the output includes extra documents that are not required
 - the generated workflow is generic enough to fit any role
 - metadata and SKILL.md describe different scopes
+- `README.md` is missing, misleading, or inconsistent with the actual skill contents
+- the skill's main value comes from platform-specific wording instead of portable workflow guidance
+- repository adapter details are more prominent than the role's actual operating logic
+- the skill assumes one model family is required even though the workflow is portable
+- third-party material informed the port but the original source is not acknowledged
 
 ## Style
 

--- a/skills/tools/skill-porting-engineer/agents/openai.yaml
+++ b/skills/tools/skill-porting-engineer/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Skill Porting Engineer"
-  short_description: "Convert source agent docs into local skills"
-  default_prompt: "Use $skill-porting-engineer to turn an upstream agent or prompt document into a local skill that matches this repository's conventions."
+  short_description: "Port external agent specs into local skills"
+  default_prompt: "Use $skill-porting-engineer to adapt an upstream agent spec, prompt file, or role document into a local skill while keeping the core workflow neutral and the repository-specific packaging minimal."


### PR DESCRIPTION
This PR strengthens the `skill-porting-engineer` skill around portability, review, and attribution.

It updates the skill to separate neutral capability from
repository-specific packaging, adds a second-pass audit step via `$skill-creator` when available, and requires third-party attribution plus a human-facing `README.md` in the
porting workflow.

It also refreshes `agents/openai.yaml` so the interface metadata matches the narrower, more portable skill definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill-porting-engineer guidelines with enhanced validation processes and clearer workflow steps for importing external agent specifications
  * Refined interface descriptions for improved clarity
  * Expanded required outputs to include README documentation standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->