### PR TITLE
feat(code-review): add ported review skill

### DIFF
--- a/skills/code-review/README.md
+++ b/skills/code-review/README.md
@@ -1,0 +1,36 @@
+# code-review
+
+Local skill for requesting or performing a focused code review on a defined change set.
+
+## Scope
+
+- define a review range with git SHAs
+- summarize implementation and requirements for the reviewer
+- dispatch a reviewer when available, or review directly in-session
+- report findings by severity before proceeding
+
+## Structure
+
+```text
+code-review/
+├── SKILL.md
+├── README.md
+├── references/
+│   └── reviewer-guide.md
+└── agents/
+    └── openai.yaml
+```
+
+## Notes
+
+This port keeps the upstream intent of reviewing small, explicit change sets early and often, but removes platform-specific dependency on `superpowers:code-reviewer`. In this repository, the skill can be used with a local reviewer/subagent if one exists, or directly by the current agent using the same review brief and severity-based output.
+
+## Source Attribution
+
+This skill is a localized adaptation of third-party source material:
+
+- Author/Repository: `obra/superpowers`
+- Upstream path: `skills/requesting-code-review/SKILL.md`
+- URL: <https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md>
+- Upstream path: `skills/requesting-code-review/code-reviewer.md`
+- URL: <https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/code-reviewer.md>

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: code-review
+description: Request or perform a git-backed code review for a defined diff or SHA range using implementation context and requirements. Use when finishing a task, completing a major feature, preparing to merge, or when you need a fresh review before proceeding.
+---
+
+# Code Review
+
+Request or perform code review before issues compound.
+
+## Operating Mode
+
+Act as a pragmatic review coordinator first, and a reviewer second.
+
+Prioritize:
+
+- clear review scope before opinions
+- requirement alignment before style nits
+- bugs and regressions before polish
+- explicit evidence before confidence
+
+Review early and review often.
+
+## Workflow
+
+Follow this sequence unless the user asks for only one part of the review flow.
+
+### 1. Define the review scope
+
+Choose the smallest meaningful diff to review.
+
+Prefer:
+
+- branch review: `git merge-base origin/main HEAD` to `HEAD`
+- task review: previous task commit to `HEAD`
+- single-commit review: `HEAD~1` to `HEAD`
+
+Use commands such as:
+
+```bash
+git merge-base origin/main HEAD
+git rev-parse HEAD
+git log --oneline --decorate -n 10
+```
+
+If the change set is too large or mixes unrelated work, call that out and split the review scope before continuing.
+
+### 2. Gather review context
+
+Capture the minimum context a reviewer needs:
+
+- what was implemented
+- plan, requirements, or acceptance criteria
+- known risks or edge cases
+- tests added, updated, or still missing
+- exact `BASE_SHA` and `HEAD_SHA`
+
+Do not rely on session history. Summarize the relevant context explicitly.
+
+### 3. Choose the review path
+
+If a dedicated review subagent or local review skill is available, dispatch it with the prepared scope and context.
+
+If no dedicated reviewer is available, perform the review directly in the current session using the same scope and context.
+
+When delegating, pass only the material needed for review:
+
+- implementation summary
+- requirements or plan reference
+- `BASE_SHA`
+- `HEAD_SHA`
+- brief description of the change
+
+### 4. Review the change set
+
+Inspect the diff against the stated requirements.
+
+Focus on:
+
+- correctness bugs
+- missing requirements
+- behavioral regressions
+- unsafe migrations or rollout risks
+- missing or weak tests
+- security, reliability, and performance issues when relevant
+
+Prefer review commands such as:
+
+```bash
+git diff <base>..<head>
+git log <base>..<head> --stat
+```
+
+For the detailed reviewer checklist and findings template, read [references/reviewer-guide.md](references/reviewer-guide.md).
+
+### 5. Return findings in severity order
+
+Report findings first.
+
+Use this structure:
+
+```markdown
+# Review Findings
+
+## Critical
+- <issue with file/line and impact>
+
+## Important
+- <issue with file/line and impact>
+
+## Minor
+- <issue with file/line and impact>
+
+## Open Questions
+- <missing context or assumption>
+
+## Assessment
+- Ready to proceed / Fix important issues first / Blocked
+```
+
+Keep findings concrete. Include file and line references when available. If there are no findings, state that explicitly and note any residual risk or test gap.
+
+### 6. Act on the review
+
+- Fix Critical issues immediately.
+- Fix Important issues before proceeding or merging.
+- Track Minor issues deliberately instead of losing them.
+- Push back on incorrect review comments with technical reasoning and evidence.
+
+Do not wave through known Important issues just because the change is small.
+
+## Review Brief Template
+
+Use this when preparing a review request:
+
+```markdown
+# Review Request
+
+## What Was Implemented
+<what changed>
+
+## Requirements
+<plan, ticket, acceptance criteria, or intended behavior>
+
+## Scope
+- BASE_SHA: <sha>
+- HEAD_SHA: <sha>
+
+## Notes for Reviewer
+- risks, edge cases, or areas needing extra scrutiny
+```
+
+## Decision Rules
+
+- Prefer reviewing a precise diff over reviewing an entire branch by default.
+- Prefer merge-base for branch reviews and `HEAD~1` only for truly single-commit reviews.
+- Escalate when scope is ambiguous, requirements are missing, or the diff contains unrelated changes.
+- Treat missing tests as a real finding when behavior changed.
+- Keep reviewer context concise and independent from hidden chain-of-thought or session history.
+
+## Red Flags
+
+Stop and reassess if:
+
+- the review scope is unclear
+- the diff includes unrelated changes
+- the requirements are too vague to judge correctness
+- the review request lacks `BASE_SHA` or `HEAD_SHA`
+- critical feedback is being ignored without evidence

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Request or perform git-backed reviews for a defined diff"
+  default_prompt: "Use $code-review to prepare a scoped git diff review request, review a SHA range against its requirements, and report findings by severity before proceeding."

--- a/skills/code-review/references/reviewer-guide.md
+++ b/skills/code-review/references/reviewer-guide.md
@@ -1,0 +1,47 @@
+# Reviewer Guide
+
+Load this reference when you are actively reviewing a diff or preparing the final findings.
+
+## Review Checklist
+
+Use this checklist to keep the review concrete:
+
+- Code quality: separation of concerns, error handling, type safety where applicable, duplication, edge cases
+- Architecture: sound design, maintainability, performance, security, integration fit
+- Testing: whether tests exercise real behavior, cover edge cases, and match the change risk
+- Requirements: spec alignment, missing functionality, unintended scope creep, documented breaking changes
+- Production readiness: migrations, backward compatibility, rollout risk, obvious bugs
+
+## Findings Structure
+
+Use this structure for the final review:
+
+```markdown
+# Review Findings
+
+## Strengths
+- <what is well done and why>
+
+## Critical
+- <issue with file/line and impact>
+
+## Important
+- <issue with file/line and impact>
+
+## Minor
+- <issue with file/line and impact>
+
+## Open Questions
+- <missing context or assumption>
+
+## Assessment
+- Ready to proceed / Fix important issues first / Blocked
+```
+
+## Writing Rules
+
+- Acknowledge concrete strengths before listing issues, but do not let praise dilute important findings.
+- Categorize findings by actual severity; do not inflate nits into Important or Critical issues.
+- For each issue, state what is wrong, why it matters, and how to fix it when not obvious.
+- Include file and line references when available.
+- If there are no findings, say so explicitly and note any residual risk or test gap.


### PR DESCRIPTION
Adds a new `code-review` skill ported from `obra/superpowers` and adapted to this repository's skill layout.

This change adds the core skill entrypoint, OpenAI metadata, a human-facing README, and a `references/reviewer-guide.md` file so the detailed reviewer rubric stays out of the main skill body.

The port keeps the upstream workflow for defining a review scope and preparing reviewer context, while localizing platform-specific reviewer dispatch into repository-neutral guidance.

No automated tests were run because this change only adds skill documentation and metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced code-review skill with comprehensive documentation covering operational workflows, reviewer coordination, and structured change-set analysis.
  * Added six-step review process with standardized findings format categorized by severity levels.
  * Provided reviewer guide including checklist, findings structure, and documentation writing conventions.
  * Added code-review agent configuration with display settings and default instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->