### PR TITLE
feat(skills): add multi-codex-orchestrator skill

### DIFF
--- a/skills/multi-codex-orchestrator/README.md
+++ b/skills/multi-codex-orchestrator/README.md
@@ -1,0 +1,66 @@
+# multi-codex-orchestrator
+
+Local Codex skill for coordinating multiple standalone Codex workers against one repository with isolated git worktrees.
+
+## Install
+
+```bash
+npx skills add https://github.com/flc1125/skills --skill multi-codex-orchestrator
+```
+
+## Scope
+
+- Split one repository task into bounded worker scopes
+- Create one git worktree per worker
+- Generate a rendered task file for each worker
+- Collect structured worker outputs and diffs
+- Merge only non-conflicting worker patches back into a target repo
+
+## Quick Start
+
+```bash
+PROJECT_DIR=output/2026-04-10/my-parallel-run
+mkdir -p "$PROJECT_DIR"
+
+./scripts/plan_tasks.sh "$PROJECT_DIR"
+# edit "$PROJECT_DIR/plan.yaml"
+
+./scripts/spawn_agents.sh "$PROJECT_DIR/plan.yaml"
+./scripts/collect_results.sh "$(cat "$PROJECT_DIR/.last-run-dir")"
+```
+
+To actually launch workers after preparing the plan:
+
+```bash
+./scripts/spawn_agents.sh "$PROJECT_DIR/plan.yaml" --run
+```
+
+## Structure
+
+```text
+multi-codex-orchestrator/
+├── SKILL.md
+├── README.md
+├── agents/
+│   └── openai.yaml
+├── assets/
+│   └── templates/
+│       ├── agent-task.md
+│       ├── plan.yaml
+│       └── result.json
+├── references/
+│   ├── conflict-policy.md
+│   ├── output-schema.md
+│   └── task-schema.md
+└── scripts/
+    ├── collect_results.sh
+    ├── merge_patches.sh
+    ├── plan_tasks.sh
+    └── spawn_agents.sh
+```
+
+## Notes
+
+- This skill is intentionally MVP-level and uses a constrained line-oriented YAML plan format.
+- Worker path ownership is expected to be exclusive; overlapping scopes are rejected before launch.
+- Runtime state is designed to live under `/tmp/` by default.

--- a/skills/multi-codex-orchestrator/SKILL.md
+++ b/skills/multi-codex-orchestrator/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when the user explicitly wants multiple Codex workers running as 
 
 1. Create a plan file from `assets/templates/plan.yaml`.
 2. Give each worker a clear `id`, `role`, `paths`, and `goal`.
-3. Use `scripts/spawn_agents.sh` to create one git worktree per worker under `/tmp/`.
+3. Use `scripts/spawn_agents.sh` to validate the plan and create one git worktree per worker under `/tmp/`.
 4. Run each worker with `codex exec` in its own worktree.
 5. Require each worker to write `result.json` in its run directory.
 6. Use `scripts/collect_results.sh` to gather artifacts and diffs.
@@ -42,7 +42,7 @@ Use this skill when the user explicitly wants multiple Codex workers running as 
 - `scripts/plan_tasks.sh`: copy a starter plan into a target project folder.
 - `scripts/spawn_agents.sh`: parse the plan, create worktrees, and launch workers.
 - `scripts/collect_results.sh`: summarize each worker run.
-- `scripts/merge_patches.sh`: apply worker commits or diffs into the integration branch.
+- `scripts/merge_patches.sh`: verify worker status and apply non-conflicting diffs into the integration branch.
 - `references/task-schema.md`: the supported plan shape.
 - `references/output-schema.md`: required worker outputs.
 - `references/conflict-policy.md`: what to do when scopes collide.
@@ -93,11 +93,13 @@ Each worker should:
 - leave code changes in its worktree
 - avoid rebasing, merging, or force-pushing
 
+Before launch, the coordinator should reject any plan where two workers own overlapping paths.
+
 ## Validation
 
 - Use `scripts/collect_results.sh` first.
 - Review `result.json`, `last-message.txt`, and `diff.patch` for each worker.
-- Only then apply `scripts/merge_patches.sh`.
+- Only then apply `scripts/merge_patches.sh`, which will refuse blocked or conflicting worker outputs.
 
 ## Notes
 

--- a/skills/multi-codex-orchestrator/SKILL.md
+++ b/skills/multi-codex-orchestrator/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: multi-codex-orchestrator
 description: Orchestrate multiple standalone Codex workers for parallel repository tasks. Use when the user wants task decomposition, isolated worktrees, structured worker outputs, patch collection, and final integration by a single coordinator.
+metadata:
+  name: Multi Codex Orchestrator
+  description: Coordinate parallel Codex workers for isolated repository task execution.
+  author: Flc
+  created: 2026-04-10T15:40:40Z
 ---
 
 # Multi Codex Orchestrator

--- a/skills/multi-codex-orchestrator/SKILL.md
+++ b/skills/multi-codex-orchestrator/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: multi-codex-orchestrator
+description: Orchestrate multiple standalone Codex workers for parallel repository tasks. Use when the user wants task decomposition, isolated worktrees, structured worker outputs, patch collection, and final integration by a single coordinator.
+---
+
+# Multi Codex Orchestrator
+
+Use this skill when the user explicitly wants multiple Codex workers running as independent agents, rather than relying on built-in sub-agent behavior.
+
+## When To Use
+
+- The task can be split into mostly independent workstreams.
+- Each worker can own a bounded path set or responsibility.
+- The coordinator can validate and integrate outputs at the end.
+
+## When Not To Use
+
+- The task is small enough for one agent.
+- Several workers would need to edit the same core files.
+- The task is highly sequential and cannot benefit from parallelism.
+
+## Default Execution Model
+
+1. Create a plan file from `assets/templates/plan.yaml`.
+2. Give each worker a clear `id`, `role`, `paths`, and `goal`.
+3. Use `scripts/spawn_agents.sh` to create one git worktree per worker under `/tmp/`.
+4. Run each worker with `codex exec` in its own worktree.
+5. Require each worker to write `result.json` in its run directory.
+6. Use `scripts/collect_results.sh` to gather artifacts and diffs.
+7. Integrate centrally. Do not let workers merge each other's changes.
+
+## Hard Rules
+
+- One worker owns one write scope.
+- Default to isolated git worktrees, not one shared writable tree.
+- Workers must produce structured outputs, not just free-form prose.
+- The coordinator must re-validate before integrating.
+- If two workers need the same file, redesign the split or serialize the work.
+
+## File Layout
+
+- `scripts/plan_tasks.sh`: copy a starter plan into a target project folder.
+- `scripts/spawn_agents.sh`: parse the plan, create worktrees, and launch workers.
+- `scripts/collect_results.sh`: summarize each worker run.
+- `scripts/merge_patches.sh`: apply worker commits or diffs into the integration branch.
+- `references/task-schema.md`: the supported plan shape.
+- `references/output-schema.md`: required worker outputs.
+- `references/conflict-policy.md`: what to do when scopes collide.
+
+## Quick Start
+
+```bash
+PROJECT_DIR=output/2026-04-10/my-parallel-run
+mkdir -p "$PROJECT_DIR"
+
+./scripts/plan_tasks.sh "$PROJECT_DIR"
+# edit "$PROJECT_DIR/plan.yaml"
+
+./scripts/spawn_agents.sh "$PROJECT_DIR/plan.yaml"
+./scripts/collect_results.sh "$(cat "$PROJECT_DIR/.last-run-dir")"
+```
+
+## Plan Format
+
+Read `references/task-schema.md` before editing `plan.yaml`.
+
+This MVP expects a small, line-oriented YAML shape:
+
+```yaml
+goal: Add RBAC to the app
+repo_path: /abs/path/to/repo
+base_branch: main
+run_root: /tmp/multi-codex-orchestrator
+agents:
+  - id: analyst
+    role: analyze
+    paths: src/auth,src/models
+    goal: Inspect current auth model and propose changes
+  - id: backend
+    role: implement
+    paths: src/auth,src/api
+    goal: Implement middleware and API changes
+```
+
+## Worker Prompting
+
+The launcher renders `assets/templates/agent-task.md` for each worker and appends the worker-specific fields from the plan.
+
+Each worker should:
+
+- stay inside its owned paths
+- write `result.json`
+- leave code changes in its worktree
+- avoid rebasing, merging, or force-pushing
+
+## Validation
+
+- Use `scripts/collect_results.sh` first.
+- Review `result.json`, `last-message.txt`, and `diff.patch` for each worker.
+- Only then apply `scripts/merge_patches.sh`.
+
+## Notes
+
+- This is an MVP skill. It favors explicit structure over clever automation.
+- If you need more flexible schemas later, replace the shell YAML parsing with a dedicated parser.

--- a/skills/multi-codex-orchestrator/agents/openai.yaml
+++ b/skills/multi-codex-orchestrator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Multi Codex Orchestrator"
+  short_description: "Coordinate isolated Codex workers for parallel repo tasks"
+  default_prompt: "Use $multi-codex-orchestrator to split a repository task into isolated worker scopes, launch worktrees safely, and collect structured results for central integration."

--- a/skills/multi-codex-orchestrator/assets/templates/agent-task.md
+++ b/skills/multi-codex-orchestrator/assets/templates/agent-task.md
@@ -1,0 +1,43 @@
+# Worker Task
+
+You are one worker inside a multi-Codex orchestration run.
+
+## Global Goal
+
+{{GLOBAL_GOAL}}
+
+## Your Assignment
+
+- Worker ID: `{{AGENT_ID}}`
+- Role: `{{AGENT_ROLE}}`
+- Owned paths: `{{OWNED_PATHS}}`
+- Worker goal: `{{AGENT_GOAL}}`
+
+## Rules
+
+- Only edit files inside your owned paths unless the task explicitly requires a nearby test or config file.
+- Do not modify git remotes, branches, or history.
+- Do not merge, rebase, or force push.
+- If blocked, stop and explain the blocker instead of guessing.
+
+## Deliverables
+
+Before finishing, write a `result.json` file in this exact run directory:
+
+`{{RUN_DIR}}/result.json`
+
+The file must include:
+
+- `agent_id`
+- `status`
+- `summary`
+- `owned_paths`
+- `tests`
+- `risks`
+- `next_action`
+
+Also leave your code changes in the worktree. The coordinator will collect `git diff`.
+
+## Final Message
+
+In your final response, summarize what changed, what was not completed, and any risks the coordinator should inspect.

--- a/skills/multi-codex-orchestrator/assets/templates/plan.yaml
+++ b/skills/multi-codex-orchestrator/assets/templates/plan.yaml
@@ -11,7 +11,3 @@ agents:
     role: implement
     paths: src/auth,src/api
     goal: Implement the approved changes in the owned paths
-  - id: reviewer
-    role: review
-    paths: src/auth,src/api
-    goal: Review the implementation for correctness and missing tests

--- a/skills/multi-codex-orchestrator/assets/templates/plan.yaml
+++ b/skills/multi-codex-orchestrator/assets/templates/plan.yaml
@@ -1,0 +1,17 @@
+goal: Replace this with the overall objective
+repo_path: /absolute/path/to/repository
+base_branch: main
+run_root: /tmp/multi-codex-orchestrator
+agents:
+  - id: analyst
+    role: analyze
+    paths: src/auth,src/models
+    goal: Inspect the current design and describe the required changes
+  - id: implementer
+    role: implement
+    paths: src/auth,src/api
+    goal: Implement the approved changes in the owned paths
+  - id: reviewer
+    role: review
+    paths: src/auth,src/api
+    goal: Review the implementation for correctness and missing tests

--- a/skills/multi-codex-orchestrator/assets/templates/result.json
+++ b/skills/multi-codex-orchestrator/assets/templates/result.json
@@ -1,0 +1,15 @@
+{
+  "agent_id": "replace-me",
+  "status": "done",
+  "summary": "Replace this with the actual outcome",
+  "owned_paths": [
+    "src/example"
+  ],
+  "tests": {
+    "ran": false,
+    "passed": false,
+    "command": ""
+  },
+  "risks": [],
+  "next_action": "ready for coordinator review"
+}

--- a/skills/multi-codex-orchestrator/references/conflict-policy.md
+++ b/skills/multi-codex-orchestrator/references/conflict-policy.md
@@ -1,0 +1,20 @@
+# Conflict Policy
+
+Use these rules before launching workers and again before integrating output.
+
+## Preventive Rules
+
+- Give each worker exclusive write ownership of its paths.
+- If two workers need the same directory, split by file ownership or serialize the work.
+- Keep review and test workers read-heavy when possible.
+
+## Integration Rules
+
+- Do not merge blindly. Inspect `diff.patch` and `result.json` together.
+- If two workers touch the same file, stop and resolve manually.
+- Prefer replaying small changes into the coordinator branch over merging opaque worker history.
+
+## Escalation
+
+- If a worker exceeds scope, treat it as a failed run and relaunch with a narrower prompt.
+- If a worker cannot finish without another worker's result, convert the plan from parallel to staged.

--- a/skills/multi-codex-orchestrator/references/output-schema.md
+++ b/skills/multi-codex-orchestrator/references/output-schema.md
@@ -1,0 +1,40 @@
+# Output Schema
+
+Each worker run should produce these artifacts in its run directory:
+
+- `task.md`: the fully rendered task prompt used for the worker
+- `last-message.txt`: final Codex message captured by `codex exec -o`
+- `result.json`: structured self-report written by the worker
+- `diff.patch`: `git diff` output from the worker worktree
+- `commit.txt`: optional commit hash if the worker created a local commit
+- `codex.jsonl`: optional raw event log if you enable `--json`
+
+## `result.json` Shape
+
+```json
+{
+  "agent_id": "backend",
+  "status": "done",
+  "summary": "Implemented RBAC middleware and policy checks",
+  "owned_paths": ["src/auth", "src/api"],
+  "tests": {
+    "ran": true,
+    "passed": true,
+    "command": "go test ./..."
+  },
+  "risks": [],
+  "next_action": "ready for coordinator review"
+}
+```
+
+## Status Values
+
+- `done`
+- `blocked`
+- `failed`
+
+## Minimum Expectations
+
+- `summary` must describe the actual outcome, not the plan.
+- `owned_paths` must match the worker scope from the plan.
+- `next_action` should tell the coordinator what to do next.

--- a/skills/multi-codex-orchestrator/references/task-schema.md
+++ b/skills/multi-codex-orchestrator/references/task-schema.md
@@ -1,0 +1,47 @@
+# Task Schema
+
+The current launcher supports a constrained `plan.yaml` format. Keep it simple.
+
+## Required Top-Level Fields
+
+- `goal`: overall objective for the run
+- `repo_path`: absolute path to the repository to fork into worktrees
+- `base_branch`: branch each worktree starts from
+- `run_root`: absolute path under `/tmp/` used for runtime state
+- `agents`: list of workers
+
+## Required Agent Fields
+
+- `id`: unique short identifier, lowercase letters, digits, hyphens
+- `role`: one of `analyze`, `implement`, `test`, `review`, `docs`
+- `paths`: comma-separated repository paths owned by the worker
+- `goal`: worker-local objective
+
+## Example
+
+```yaml
+goal: Add RBAC to the app
+repo_path: /Users/name/code/my-app
+base_branch: main
+run_root: /tmp/multi-codex-orchestrator
+agents:
+  - id: analyst
+    role: analyze
+    paths: src/auth,src/models
+    goal: Inspect auth model and suggest migration approach
+  - id: backend
+    role: implement
+    paths: src/auth,src/api
+    goal: Implement RBAC middleware and policy checks
+  - id: tests
+    role: test
+    paths: src/auth,test
+    goal: Add regression tests for role checks
+```
+
+## Constraints
+
+- Keep each `goal` on one line.
+- Keep each `paths` value on one line.
+- Do not use nested YAML objects beyond the shown agent list.
+- Do not include `_archives/` paths by default.

--- a/skills/multi-codex-orchestrator/scripts/collect_results.sh
+++ b/skills/multi-codex-orchestrator/scripts/collect_results.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <run-dir>" >&2
+  exit 1
+fi
+
+RUN_DIR="$1"
+WORKTREES_DIR="$RUN_DIR/worktrees"
+AGENTS_DIR="$RUN_DIR/agents"
+
+if [[ ! -d "$RUN_DIR" ]]; then
+  echo "run dir not found: $RUN_DIR" >&2
+  exit 1
+fi
+
+for agent_dir in "$AGENTS_DIR"/*; do
+  [[ -d "$agent_dir" ]] || continue
+  agent_id="$(basename "$agent_dir")"
+  worktree_dir="$WORKTREES_DIR/$agent_id"
+  patch_file="$agent_dir/diff.patch"
+
+  if [[ -d "$worktree_dir" ]]; then
+    git -C "$worktree_dir" diff > "$patch_file"
+  fi
+
+  echo "agent: $agent_id"
+  [[ -f "$agent_dir/result.json" ]] && echo "  result: $agent_dir/result.json" || echo "  result: missing"
+  [[ -f "$agent_dir/last-message.txt" ]] && echo "  message: $agent_dir/last-message.txt" || echo "  message: missing"
+  [[ -s "$patch_file" ]] && echo "  diff: $patch_file" || echo "  diff: empty"
+done

--- a/skills/multi-codex-orchestrator/scripts/collect_results.sh
+++ b/skills/multi-codex-orchestrator/scripts/collect_results.sh
@@ -22,6 +22,18 @@ for agent_dir in "$AGENTS_DIR"/*; do
   patch_file="$agent_dir/diff.patch"
 
   if [[ -d "$worktree_dir" ]]; then
+    if ! git -C "$worktree_dir" diff --cached --quiet; then
+      echo "error: staged changes detected in $worktree_dir that would be omitted from $patch_file" >&2
+      echo "action: run 'git -C \"$worktree_dir\" diff --cached' and export staged changes before collecting results" >&2
+      exit 1
+    fi
+
+    if [[ -n "$(git -C "$worktree_dir" ls-files --others --exclude-standard)" ]]; then
+      echo "error: untracked files detected in $worktree_dir that would be omitted from $patch_file" >&2
+      echo "action: track new files or include them in a commit before collecting results" >&2
+      exit 1
+    fi
+
     git -C "$worktree_dir" diff > "$patch_file"
   fi
 

--- a/skills/multi-codex-orchestrator/scripts/merge_patches.sh
+++ b/skills/multi-codex-orchestrator/scripts/merge_patches.sh
@@ -10,6 +10,36 @@ RUN_DIR="$1"
 TARGET_REPO="$2"
 AGENTS_DIR="$RUN_DIR/agents"
 
+get_result_status() {
+  local result_file="$1"
+  sed -n 's/^[[:space:]]*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$result_file" | head -n 1
+}
+
+collect_patch_files() {
+  sed -n 's|^diff --git a/\(.*\) b/.*$|\1|p' "$1"
+}
+
+record_touch() {
+  local owner="$1"
+  local file="$2"
+  local entry
+  local existing_file
+  local existing_owner
+
+  if (( ${#touched_file_records[@]} > 0 )); then
+    for entry in "${touched_file_records[@]}"; do
+      existing_file="${entry#*:}"
+      existing_owner="${entry%%:*}"
+      if [[ "$existing_file" == "$file" ]]; then
+        echo "file conflict between $existing_owner and $owner: $file" >&2
+        exit 1
+      fi
+    done
+  fi
+
+  touched_file_records+=("$owner:$file")
+}
+
 if [[ ! -d "$AGENTS_DIR" ]]; then
   echo "agents dir not found: $AGENTS_DIR" >&2
   exit 1
@@ -20,12 +50,39 @@ if [[ ! -d "$TARGET_REPO/.git" ]]; then
   exit 1
 fi
 
+declare -a touched_file_records=()
+declare -a patch_files=()
+
 for patch_file in "$AGENTS_DIR"/*/diff.patch; do
   [[ -f "$patch_file" ]] || continue
   if [[ ! -s "$patch_file" ]]; then
     continue
   fi
 
+  agent_dir="$(dirname "$patch_file")"
+  agent_id="$(basename "$agent_dir")"
+  result_file="$agent_dir/result.json"
+
+  if [[ ! -f "$result_file" ]]; then
+    echo "missing result.json for $agent_id: $result_file" >&2
+    exit 1
+  fi
+
+  status="$(get_result_status "$result_file")"
+  if [[ "$status" != "done" ]]; then
+    echo "refusing to merge $agent_id with status '$status'" >&2
+    exit 1
+  fi
+
+  while IFS= read -r touched_file; do
+    [[ -z "$touched_file" ]] && continue
+    record_touch "$agent_id" "$touched_file"
+  done < <(collect_patch_files "$patch_file")
+
+  patch_files+=("$patch_file")
+done
+
+for patch_file in "${patch_files[@]}"; do
   echo "applying: $patch_file"
   git -C "$TARGET_REPO" apply --3way "$patch_file"
 done

--- a/skills/multi-codex-orchestrator/scripts/merge_patches.sh
+++ b/skills/multi-codex-orchestrator/scripts/merge_patches.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <run-dir> <target-repo>" >&2
+  exit 1
+fi
+
+RUN_DIR="$1"
+TARGET_REPO="$2"
+AGENTS_DIR="$RUN_DIR/agents"
+
+if [[ ! -d "$AGENTS_DIR" ]]; then
+  echo "agents dir not found: $AGENTS_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -d "$TARGET_REPO/.git" ]]; then
+  echo "target repo is not a git repository: $TARGET_REPO" >&2
+  exit 1
+fi
+
+for patch_file in "$AGENTS_DIR"/*/diff.patch; do
+  [[ -f "$patch_file" ]] || continue
+  if [[ ! -s "$patch_file" ]]; then
+    continue
+  fi
+
+  echo "applying: $patch_file"
+  git -C "$TARGET_REPO" apply --3way "$patch_file"
+done
+
+echo "patches applied to: $TARGET_REPO"
+echo "next: review staged changes, resolve conflicts if any, then run validation"

--- a/skills/multi-codex-orchestrator/scripts/merge_patches.sh
+++ b/skills/multi-codex-orchestrator/scripts/merge_patches.sh
@@ -12,7 +12,7 @@ AGENTS_DIR="$RUN_DIR/agents"
 
 get_result_status() {
   local result_file="$1"
-  sed -n 's/^[[:space:]]*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$result_file" | head -n 1
+  sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$result_file" | head -n 1
 }
 
 collect_patch_files() {
@@ -84,8 +84,11 @@ done
 
 for patch_file in "${patch_files[@]}"; do
   echo "applying: $patch_file"
-  git -C "$TARGET_REPO" apply --3way "$patch_file"
+  if ! git -C "$TARGET_REPO" apply --3way "$patch_file"; then
+    echo "failed to apply patch: $patch_file" >&2
+    exit 1
+  fi
 done
 
 echo "patches applied to: $TARGET_REPO"
-echo "next: review staged changes, resolve conflicts if any, then run validation"
+echo "next: review working tree changes, resolve conflicts if any, then run validation"

--- a/skills/multi-codex-orchestrator/scripts/plan_tasks.sh
+++ b/skills/multi-codex-orchestrator/scripts/plan_tasks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <project-dir>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_DIR="$1"
+PLAN_FILE="$PROJECT_DIR/plan.yaml"
+
+mkdir -p "$PROJECT_DIR"
+
+if [[ -e "$PLAN_FILE" ]]; then
+  echo "plan already exists: $PLAN_FILE" >&2
+  exit 1
+fi
+
+cp "$ROOT_DIR/assets/templates/plan.yaml" "$PLAN_FILE"
+
+cat <<EOF
+created: $PLAN_FILE
+
+next:
+  1. edit repo_path, goal, and agent blocks
+  2. keep run_root under /tmp/
+  3. run: $ROOT_DIR/scripts/spawn_agents.sh $PLAN_FILE
+EOF

--- a/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
+++ b/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
@@ -38,6 +38,9 @@ normalize_path() {
   value="$(trim "$1")"
   value="${value#./}"
   value="${value%/}"
+  if [[ "$value" == "." ]]; then
+    value=""
+  fi
   printf '%s' "$value"
 }
 
@@ -68,8 +71,13 @@ array_contains() {
 strip_quotes() {
   local value
   value="$(trim "$1")"
-  value="${value%\"}"
-  value="${value#\"}"
+  if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+    value="${value#\"}"
+    value="${value%\"}"
+  elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+    value="${value#\'}"
+    value="${value%\'}"
+  fi
   printf '%s' "$value"
 }
 
@@ -196,7 +204,7 @@ for i in "${!agent_ids[@]}"; do
   IFS=',' read -r -a left_paths <<< "$owned_paths"
   for raw_left_path in "${left_paths[@]}"; do
     left_path="$(normalize_path "$raw_left_path")"
-    if [[ -z "$left_path" ]]; then
+    if [[ -z "$left_path" && "$(trim "$raw_left_path")" != "." ]]; then
       echo "agent $agent_id contains an empty path entry" >&2
       exit 1
     fi
@@ -210,8 +218,13 @@ for i in "${!agent_ids[@]}"; do
       IFS=',' read -r -a right_paths <<< "${agent_paths[$j]}"
       for raw_right_path in "${right_paths[@]}"; do
         right_path="$(normalize_path "$raw_right_path")"
-        if [[ -z "$right_path" ]]; then
+        if [[ -z "$right_path" && "$(trim "$raw_right_path")" != "." ]]; then
           echo "agent $other_agent_id contains an empty path entry" >&2
+          exit 1
+        fi
+
+        if [[ -z "$left_path" || -z "$right_path" ]]; then
+          echo "path overlap between $agent_id:$(trim "$raw_left_path") and $other_agent_id:$(trim "$raw_right_path")" >&2
           exit 1
         fi
 

--- a/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
+++ b/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
@@ -25,6 +25,46 @@ trim() {
   printf '%s' "$value"
 }
 
+escape_sed_replacement() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//&/\\&}"
+  value="${value//|/\\|}"
+  printf '%s' "$value"
+}
+
+normalize_path() {
+  local value
+  value="$(trim "$1")"
+  value="${value#./}"
+  value="${value%/}"
+  printf '%s' "$value"
+}
+
+paths_overlap() {
+  local left="$1"
+  local right="$2"
+
+  [[ -z "$left" || -z "$right" ]] && return 1
+  [[ "$left" == "$right" ]] && return 0
+  [[ "$left" == "$right/"* ]] && return 0
+  [[ "$right" == "$left/"* ]] && return 0
+  return 1
+}
+
+array_contains() {
+  local needle="$1"
+  shift
+
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 strip_quotes() {
   local value
   value="$(trim "$1")"
@@ -114,8 +154,18 @@ if [[ -z "$goal" || -z "$repo_path" || -z "$base_branch" || -z "$run_root" ]]; t
   exit 1
 fi
 
+if [[ "$run_root" != /tmp/* ]]; then
+  echo "run_root must be under /tmp/: $run_root" >&2
+  exit 1
+fi
+
 if [[ ! -d "$repo_path" ]]; then
   echo "repo_path does not exist: $repo_path" >&2
+  exit 1
+fi
+
+if [[ ! -d "$repo_path/.git" ]]; then
+  echo "repo_path is not a git repository: $repo_path" >&2
   exit 1
 fi
 
@@ -123,6 +173,56 @@ if [[ ${#agent_ids[@]} -eq 0 ]]; then
   echo "plan contains no agents" >&2
   exit 1
 fi
+
+declare -a seen_agent_ids=()
+
+for i in "${!agent_ids[@]}"; do
+  agent_id="${agent_ids[$i]}"
+  agent_role="${agent_roles[$i]}"
+  owned_paths="${agent_paths[$i]}"
+  agent_goal="${agent_goals[$i]}"
+
+  if [[ -z "$agent_id" || -z "$agent_role" || -z "$owned_paths" || -z "$agent_goal" ]]; then
+    echo "agent entry $((i + 1)) is incomplete" >&2
+    exit 1
+  fi
+
+  if (( ${#seen_agent_ids[@]} > 0 )) && array_contains "$agent_id" "${seen_agent_ids[@]}"; then
+    echo "duplicate agent id: $agent_id" >&2
+    exit 1
+  fi
+  seen_agent_ids+=("$agent_id")
+
+  IFS=',' read -r -a left_paths <<< "$owned_paths"
+  for raw_left_path in "${left_paths[@]}"; do
+    left_path="$(normalize_path "$raw_left_path")"
+    if [[ -z "$left_path" ]]; then
+      echo "agent $agent_id contains an empty path entry" >&2
+      exit 1
+    fi
+
+    for j in "${!agent_ids[@]}"; do
+      if (( j <= i )); then
+        continue
+      fi
+
+      other_agent_id="${agent_ids[$j]}"
+      IFS=',' read -r -a right_paths <<< "${agent_paths[$j]}"
+      for raw_right_path in "${right_paths[@]}"; do
+        right_path="$(normalize_path "$raw_right_path")"
+        if [[ -z "$right_path" ]]; then
+          echo "agent $other_agent_id contains an empty path entry" >&2
+          exit 1
+        fi
+
+        if paths_overlap "$left_path" "$right_path"; then
+          echo "path overlap between $agent_id:$left_path and $other_agent_id:$right_path" >&2
+          exit 1
+        fi
+      done
+    done
+  done
+done
 
 timestamp="$(date +%Y%m%d-%H%M%S)"
 run_dir="$run_root/run-$timestamp"
@@ -138,11 +238,6 @@ for i in "${!agent_ids[@]}"; do
   owned_paths="${agent_paths[$i]}"
   agent_goal="${agent_goals[$i]}"
 
-  if [[ -z "$agent_id" || -z "$agent_role" || -z "$owned_paths" || -z "$agent_goal" ]]; then
-    echo "agent entry $((i + 1)) is incomplete" >&2
-    exit 1
-  fi
-
   worktree_dir="$worktrees_dir/$agent_id"
   agent_run_dir="$runs_dir/$agent_id"
   task_file="$agent_run_dir/task.md"
@@ -154,12 +249,12 @@ for i in "${!agent_ids[@]}"; do
   git -C "$repo_path" worktree add --detach "$worktree_dir" "$base_branch" >/dev/null
 
   sed \
-    -e "s|{{GLOBAL_GOAL}}|$goal|g" \
-    -e "s|{{AGENT_ID}}|$agent_id|g" \
-    -e "s|{{AGENT_ROLE}}|$agent_role|g" \
-    -e "s|{{OWNED_PATHS}}|$owned_paths|g" \
-    -e "s|{{AGENT_GOAL}}|$agent_goal|g" \
-    -e "s|{{RUN_DIR}}|$agent_run_dir|g" \
+    -e "s|{{GLOBAL_GOAL}}|$(escape_sed_replacement "$goal")|g" \
+    -e "s|{{AGENT_ID}}|$(escape_sed_replacement "$agent_id")|g" \
+    -e "s|{{AGENT_ROLE}}|$(escape_sed_replacement "$agent_role")|g" \
+    -e "s|{{OWNED_PATHS}}|$(escape_sed_replacement "$owned_paths")|g" \
+    -e "s|{{AGENT_GOAL}}|$(escape_sed_replacement "$agent_goal")|g" \
+    -e "s|{{RUN_DIR}}|$(escape_sed_replacement "$agent_run_dir")|g" \
     "$TASK_TEMPLATE" > "$task_file"
 
   if [[ "$MODE" == "--run" ]]; then

--- a/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
+++ b/skills/multi-codex-orchestrator/scripts/spawn_agents.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <plan.yaml> [--run]" >&2
+  exit 1
+fi
+
+PLAN_FILE="$1"
+MODE="${2:-}"
+
+if [[ ! -f "$PLAN_FILE" ]]; then
+  echo "plan not found: $PLAN_FILE" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TASK_TEMPLATE="$ROOT_DIR/assets/templates/agent-task.md"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+strip_quotes() {
+  local value
+  value="$(trim "$1")"
+  value="${value%\"}"
+  value="${value#\"}"
+  printf '%s' "$value"
+}
+
+goal=""
+repo_path=""
+base_branch=""
+run_root=""
+
+declare -a agent_ids=()
+declare -a agent_roles=()
+declare -a agent_paths=()
+declare -a agent_goals=()
+
+current_id=""
+current_role=""
+current_paths=""
+current_goal=""
+in_agents=0
+
+flush_agent() {
+  if [[ -n "$current_id" ]]; then
+    agent_ids+=("$current_id")
+    agent_roles+=("$current_role")
+    agent_paths+=("$current_paths")
+    agent_goals+=("$current_goal")
+  fi
+  current_id=""
+  current_role=""
+  current_paths=""
+  current_goal=""
+}
+
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+  line="$(trim "$raw_line")"
+  [[ -z "$line" ]] && continue
+  [[ "$line" == \#* ]] && continue
+
+  if [[ "$line" == "agents:" ]]; then
+    in_agents=1
+    continue
+  fi
+
+  if [[ $in_agents -eq 0 ]]; then
+    case "$line" in
+      goal:*)
+        goal="$(strip_quotes "${line#goal:}")"
+        ;;
+      repo_path:*)
+        repo_path="$(strip_quotes "${line#repo_path:}")"
+        ;;
+      base_branch:*)
+        base_branch="$(strip_quotes "${line#base_branch:}")"
+        ;;
+      run_root:*)
+        run_root="$(strip_quotes "${line#run_root:}")"
+        ;;
+    esac
+    continue
+  fi
+
+  case "$line" in
+    -\ id:*)
+      flush_agent
+      current_id="$(strip_quotes "${line#- id:}")"
+      ;;
+    role:*)
+      current_role="$(strip_quotes "${line#role:}")"
+      ;;
+    paths:*)
+      current_paths="$(strip_quotes "${line#paths:}")"
+      ;;
+    goal:*)
+      current_goal="$(strip_quotes "${line#goal:}")"
+      ;;
+  esac
+done < "$PLAN_FILE"
+
+flush_agent
+
+if [[ -z "$goal" || -z "$repo_path" || -z "$base_branch" || -z "$run_root" ]]; then
+  echo "plan is missing one of: goal, repo_path, base_branch, run_root" >&2
+  exit 1
+fi
+
+if [[ ! -d "$repo_path" ]]; then
+  echo "repo_path does not exist: $repo_path" >&2
+  exit 1
+fi
+
+if [[ ${#agent_ids[@]} -eq 0 ]]; then
+  echo "plan contains no agents" >&2
+  exit 1
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+run_dir="$run_root/run-$timestamp"
+worktrees_dir="$run_dir/worktrees"
+runs_dir="$run_dir/agents"
+
+mkdir -p "$worktrees_dir" "$runs_dir"
+printf '%s\n' "$run_dir" > "$(dirname "$PLAN_FILE")/.last-run-dir"
+
+for i in "${!agent_ids[@]}"; do
+  agent_id="${agent_ids[$i]}"
+  agent_role="${agent_roles[$i]}"
+  owned_paths="${agent_paths[$i]}"
+  agent_goal="${agent_goals[$i]}"
+
+  if [[ -z "$agent_id" || -z "$agent_role" || -z "$owned_paths" || -z "$agent_goal" ]]; then
+    echo "agent entry $((i + 1)) is incomplete" >&2
+    exit 1
+  fi
+
+  worktree_dir="$worktrees_dir/$agent_id"
+  agent_run_dir="$runs_dir/$agent_id"
+  task_file="$agent_run_dir/task.md"
+  output_file="$agent_run_dir/last-message.txt"
+  log_file="$agent_run_dir/launch.log"
+
+  mkdir -p "$agent_run_dir"
+
+  git -C "$repo_path" worktree add --detach "$worktree_dir" "$base_branch" >/dev/null
+
+  sed \
+    -e "s|{{GLOBAL_GOAL}}|$goal|g" \
+    -e "s|{{AGENT_ID}}|$agent_id|g" \
+    -e "s|{{AGENT_ROLE}}|$agent_role|g" \
+    -e "s|{{OWNED_PATHS}}|$owned_paths|g" \
+    -e "s|{{AGENT_GOAL}}|$agent_goal|g" \
+    -e "s|{{RUN_DIR}}|$agent_run_dir|g" \
+    "$TASK_TEMPLATE" > "$task_file"
+
+  if [[ "$MODE" == "--run" ]]; then
+    (
+      cd "$worktree_dir"
+      codex exec --full-auto -C "$worktree_dir" -o "$output_file" - < "$task_file"
+    ) >"$log_file" 2>&1 &
+    printf '%s\n' "$!" > "$agent_run_dir/pid"
+    echo "launched $agent_id pid=$(cat "$agent_run_dir/pid")"
+  else
+    echo "prepared $agent_id"
+  fi
+done
+
+cat <<EOF
+run_dir: $run_dir
+mode: ${MODE:---prepare-only}
+agents: ${#agent_ids[@]}
+
+next:
+  inspect tasks under $runs_dir
+  run again with --run to launch Codex workers
+  collect with: $ROOT_DIR/scripts/collect_results.sh $run_dir
+EOF


### PR DESCRIPTION
## Summary
Add a new `multi-codex-orchestrator` skill for coordinating parallel Codex workers in isolated git worktrees, with structured outputs and centralized integration.

## Changes
- add the new skill with planning, spawning, collection, and merge scripts plus task and result templates
- document the workflow, task schema, output schema, and conflict policy for multi-worker runs
- harden the MVP by validating path ownership before launch, checking worker status before merge, and rejecting conflicting patches
- add `agents/openai.yaml` metadata for skill discovery

## Motivation
- provide a repository-local skill for orchestrating multiple standalone Codex workers when isolated write scopes and explicit coordination are required

## Testing
- `bash -n skills/multi-codex-orchestrator/scripts/spawn_agents.sh`
- `bash -n skills/multi-codex-orchestrator/scripts/merge_patches.sh`
- `python3 /Users/flc/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/multi-codex-orchestrator`
- manually verified `spawn_agents.sh` rejects overlapping path ownership
- manually verified `merge_patches.sh` rejects conflicting patches touching the same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-codex-orchestrator skill to coordinate multiple isolated workers for parallel repository task execution with structured planning, result collection, and patch merging capabilities.

* **Documentation**
  * Added configuration templates, task schemas, output specifications, and conflict resolution policies for multi-worker orchestration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->