### PR TITLE
feat(memories): add project memory scaffold skill

### DIFF
--- a/skills/memories/README.md
+++ b/skills/memories/README.md
@@ -1,0 +1,45 @@
+# memories
+
+Local skill for initializing project-local memory files and agent guidance.
+
+## Install
+
+```bash
+npx skills add https://github.com/flc1125/skills --skill memories
+```
+
+## Scope
+
+- create a lightweight `.agents/memories/` scaffold by default
+- support a custom project memory directory
+- create or update agent guidance in `AGENTS.md`
+- preserve existing memory files instead of overwriting user content
+- keep future memory updates scoped to reusable, project-level knowledge
+
+## Structure
+
+```text
+memories/
+├── SKILL.md
+├── README.md
+├── agents/
+│   └── openai.yaml
+└── scripts/
+    └── init_project_memory.py
+```
+
+## Generated Project Files
+
+The scaffold creates these files in the target project memory directory:
+
+- `README.md`: purpose and maintenance rules for project memories
+- `index.md`: routing index for future agents
+- `project.md`: stable project conventions, structure, and decisions
+- `workflows.md`: repeatable validation, release, CI, and maintenance workflows
+- `lessons.md`: reusable pitfalls, fixes, and debugging lessons
+
+## Notes
+
+This skill is intentionally a scaffold, not a runtime memory database. It creates a small file-based convention that future agents can read and maintain through normal git review.
+
+The script only updates marker-managed agent guidance automatically. If a project already has a hand-written `## Project Memory` section, the script preserves it and appends a managed block instead of replacing user-authored content.

--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memories
-description: Scaffold a project-local memory directory and AGENTS.md guidance for reusable agent knowledge. Use when a user wants to initialize or refresh `.agents/memories/` or another project memory path so future agents can read and maintain durable project context.
+description: Scaffold a project-local memory directory and AGENTS.md guidance for reusable agent knowledge. Use when a user wants to initialize `.agents/memories/` or another project memory path so future agents can read and maintain durable project context.
 metadata:
   name: Memories
   description: Scaffold project-local memory files and AGENTS.md guidance for future agents.
@@ -17,10 +17,11 @@ Use this skill to initialize durable project knowledge, not to store one-off tas
 ## Workflow
 
 1. Confirm the target project root.
-2. Use `.agents/memories/` unless the user specifies another memory directory.
-3. Run `scripts/init_project_memory.py`.
-4. Review the generated or changed files.
-5. Report the memory directory and whether `AGENTS.md` was created or updated.
+2. Inspect whether the target memory directory and agent instruction file already exist.
+3. Use `.agents/memories/` unless the user specifies another memory directory.
+4. Run `scripts/init_project_memory.py`.
+5. Review the generated or changed files.
+6. Report the memory directory and whether the agent instruction file was created or updated.
 
 ## Command
 
@@ -42,6 +43,12 @@ To create memory files without touching the agent instruction file:
 python3 <skill-dir>/scripts/init_project_memory.py /path/to/project --skip-agent
 ```
 
+With an alternate agent instruction file:
+
+```bash
+python3 <skill-dir>/scripts/init_project_memory.py /path/to/project --agent-file CLAUDE.md
+```
+
 ## Generated Files
 
 The scaffold creates missing files only. Existing memory files are preserved.
@@ -58,11 +65,12 @@ By default, the script creates or updates `AGENTS.md` in the project root. It in
 
 - read `index.md` before non-trivial work;
 - open only task-relevant memory files;
-- update memories when reusable, project-specific knowledge is discovered;
+- update memories when the user requests memory maintenance or when reusable project knowledge is a natural part of the current task;
+- recommend a memory update instead of editing memory files when memory maintenance is outside the current task scope;
 - avoid one-off task notes, temporary debugging details, secrets, credentials, and conversation-specific context;
 - keep `index.md` aligned when memory files are added, removed, renamed, or materially changed.
 
-If an existing managed block or `## Project Memory` / `## Project Memories` section is present, update it instead of appending a duplicate.
+If an existing managed block is present, update it instead of appending a duplicate. If only an unmarked `## Project Memory` / `## Project Memories` section exists, preserve the user-authored section and append a managed block.
 
 ## Memory Standard
 

--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: memories
+description: Scaffold a project-local memory directory and AGENTS.md guidance for reusable agent knowledge. Use when a user wants to initialize or refresh `.agents/memories/` or another project memory path so future agents can read and maintain durable project context.
+metadata:
+  name: Memories
+  description: Scaffold project-local memory files and AGENTS.md guidance for future agents.
+  author: Flc゛
+  created: 2026-05-10T12:35:25Z
+---
+
+# Memories
+
+Scaffold lightweight, project-local memory files that future agents can read and maintain.
+
+Use this skill to initialize durable project knowledge, not to store one-off task notes. The default target is `.agents/memories/`, with `AGENTS.md` guidance for Codex-oriented future use.
+
+## Workflow
+
+1. Confirm the target project root.
+2. Use `.agents/memories/` unless the user specifies another memory directory.
+3. Run `scripts/init_project_memory.py`.
+4. Review the generated or changed files.
+5. Report the memory directory and whether `AGENTS.md` was created or updated.
+
+## Command
+
+From any location:
+
+```bash
+python3 <skill-dir>/scripts/init_project_memory.py /path/to/project
+```
+
+With a custom memory directory:
+
+```bash
+python3 <skill-dir>/scripts/init_project_memory.py /path/to/project --memory-dir docs/agent-memory
+```
+
+To create memory files without touching the agent instruction file:
+
+```bash
+python3 <skill-dir>/scripts/init_project_memory.py /path/to/project --skip-agent
+```
+
+## Generated Files
+
+The scaffold creates missing files only. Existing memory files are preserved.
+
+- `README.md`: explains the memory system, what belongs there, and what must not be stored.
+- `index.md`: routes future agents to the relevant memory files.
+- `project.md`: stores stable project conventions and durable context.
+- `workflows.md`: stores repeatable commands, release steps, CI workflows, and maintenance procedures.
+- `lessons.md`: stores reusable lessons, pitfalls, and verified fixes.
+
+## AGENTS.md Guidance
+
+By default, the script creates or updates `AGENTS.md` in the project root. It inserts a concise `## Project Memory` section that tells future agents to:
+
+- read `index.md` before non-trivial work;
+- open only task-relevant memory files;
+- update memories when reusable, project-specific knowledge is discovered;
+- avoid one-off task notes, temporary debugging details, secrets, credentials, and conversation-specific context;
+- keep `index.md` aligned when memory files are added, removed, renamed, or materially changed.
+
+If an existing managed block or `## Project Memory` / `## Project Memories` section is present, update it instead of appending a duplicate.
+
+## Memory Standard
+
+Treat memory as durable project knowledge. Add or update entries only when the information is likely to help future agents across tasks.
+
+Good memory candidates:
+
+- stable repository conventions;
+- commands or workflows that were verified locally;
+- recurring environment constraints;
+- cross-task architectural or maintenance decisions;
+- reusable debugging lessons.
+
+Do not store:
+
+- secrets, credentials, tokens, or private keys;
+- raw conversation logs;
+- single-task progress notes;
+- speculative conclusions that have not been verified;
+- noisy command output that is not reusable.

--- a/skills/memories/agents/openai.yaml
+++ b/skills/memories/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Memories"
+  short_description: "Scaffold reusable project memory files"
+  default_prompt: "Use $memories to initialize project memory files and add AGENTS.md guidance for future agents."

--- a/skills/memories/scripts/init_project_memory.py
+++ b/skills/memories/scripts/init_project_memory.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Initialize project-local memory files and AGENTS.md guidance."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import textwrap
+
+
+DEFAULT_MEMORY_DIR = ".agents/memories"
+DEFAULT_AGENT_FILE = "AGENTS.md"
+START_MARKER = "<!-- project-memory:start -->"
+END_MARKER = "<!-- project-memory:end -->"
+
+
+def clean_multiline(value: str) -> str:
+    return textwrap.dedent(value).strip() + "\n"
+
+
+def template_files(memory_dir: str) -> dict[str, str]:
+    return {
+        "README.md": clean_multiline(
+            f"""
+            # Project Memories
+
+            This directory stores durable, reusable project knowledge for future agents.
+
+            Memory belongs here when it is project-specific and likely to help across multiple tasks. Do not store one-off task notes, temporary debugging details, raw chat logs, secrets, credentials, tokens, or private keys.
+
+            ## How To Use
+
+            1. Read `index.md` before non-trivial work.
+            2. Open only the memory files relevant to the current task.
+            3. Update memories when reusable project knowledge is discovered or corrected.
+            4. Keep entries concise, actionable, and easy to review in git.
+            5. Update `index.md` when adding, removing, renaming, or materially changing memory files.
+
+            ## Default Files
+
+            - `project.md`: stable project context, conventions, and structure.
+            - `workflows.md`: reusable commands, release steps, CI routines, and maintenance procedures.
+            - `lessons.md`: pitfalls, verified fixes, and reusable debugging lessons.
+
+            Memory directory: `{memory_dir}`
+            """
+        ),
+        "index.md": clean_multiline(
+            """
+            # Memory Index
+
+            Use this index to decide which memory files are relevant before starting work.
+
+            | File | Purpose | Read When |
+            | --- | --- | --- |
+            | `project.md` | Stable project context, conventions, and structure. | You need repository orientation, naming rules, layout notes, or durable project preferences. |
+            | `workflows.md` | Reusable commands, release steps, CI routines, and maintenance procedures. | You need to run, validate, release, debug CI, or perform repeated maintenance. |
+            | `lessons.md` | Pitfalls, verified fixes, and reusable debugging lessons. | You hit a recurring issue or need prior lessons before changing behavior. |
+
+            When adding a new memory file, add a row here with its purpose and when to read it.
+            """
+        ),
+        "project.md": clean_multiline(
+            """
+            # Project Memory
+
+            Store stable, reusable project context here.
+
+            ## Conventions
+
+            - Add durable coding, naming, directory, branching, or review conventions as they are confirmed.
+
+            ## Structure
+
+            - Add stable repository layout notes that help future agents find the right files quickly.
+
+            ## Decisions
+
+            - Add long-lived technical or product decisions with brief rationale.
+            """
+        ),
+        "workflows.md": clean_multiline(
+            """
+            # Workflow Memory
+
+            Store reusable project workflows here.
+
+            ## Validation
+
+            - Add verified test, lint, build, and local validation commands.
+
+            ## Maintenance
+
+            - Add repeated maintenance routines, release steps, dependency update handling, and CI triage procedures.
+            """
+        ),
+        "lessons.md": clean_multiline(
+            """
+            # Lessons Memory
+
+            Store reusable lessons and pitfalls here.
+
+            ## Pitfalls
+
+            - Add recurring failure modes, environment constraints, and gotchas with verified workarounds.
+
+            ## Fix Patterns
+
+            - Add fixes that are likely to apply again, with the conditions that made them valid.
+            """
+        ),
+    }
+
+
+def project_memory_section(memory_dir: str) -> str:
+    return clean_multiline(
+        f"""
+        {START_MARKER}
+        ## Project Memory
+
+        Reusable project memory lives in `{memory_dir}/`.
+
+        Before non-trivial work, read `{memory_dir}/index.md` and then open only the memory files relevant to the task.
+
+        Update memories when you discover reusable project-specific knowledge that would help future agents. Do not store one-off task notes, temporary debugging details, raw chat logs, secrets, credentials, or conversation-specific context.
+
+        When changing memories, keep entries concise and actionable. Update `{memory_dir}/index.md` when adding, removing, renaming, or materially changing memory files.
+        {END_MARKER}
+        """
+    )
+
+
+def resolve_inside(root: Path, relative_path: str, option_name: str) -> Path:
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        raise SystemExit(f"{option_name} must be relative to the project root")
+
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise SystemExit(f"{option_name} must stay inside the project root") from exc
+    return resolved
+
+
+def write_missing_memory_files(root: Path, memory_dir: str) -> list[str]:
+    target = resolve_inside(root, memory_dir, "--memory-dir")
+    target.mkdir(parents=True, exist_ok=True)
+
+    actions: list[str] = []
+    for name, content in template_files(memory_dir).items():
+        path = target / name
+        if path.exists():
+            actions.append(f"kept {path.relative_to(root)}")
+            continue
+        path.write_text(content, encoding="utf-8")
+        actions.append(f"created {path.relative_to(root)}")
+    return actions
+
+
+def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[str]:
+    path = resolve_inside(root, agent_file, "--agent-file")
+    section = project_memory_section(memory_dir)
+
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# Agent Instructions\n\n" + section, encoding="utf-8")
+        return [f"created {path.relative_to(root)}"]
+
+    original = path.read_text(encoding="utf-8")
+    marker_pattern = re.compile(
+        rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}\n?",
+        re.DOTALL,
+    )
+    if marker_pattern.search(original):
+        updated = marker_pattern.sub(section, original)
+        path.write_text(updated, encoding="utf-8")
+        return [f"updated managed Project Memory block in {path.relative_to(root)}"]
+
+    heading_pattern = re.compile(
+        r"^## Project Memor(?:y|ies)\n.*?(?=^## |\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    if heading_pattern.search(original):
+        updated = heading_pattern.sub(section, original)
+        path.write_text(updated, encoding="utf-8")
+        return [f"replaced existing Project Memory section in {path.relative_to(root)}"]
+
+    separator = "" if original.endswith("\n\n") else "\n" if original.endswith("\n") else "\n\n"
+    path.write_text(original + separator + section, encoding="utf-8")
+    return [f"appended Project Memory section to {path.relative_to(root)}"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Initialize project memory files and AGENTS.md guidance.",
+    )
+    parser.add_argument(
+        "project_root",
+        nargs="?",
+        default=".",
+        help="Project root to initialize. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--memory-dir",
+        default=DEFAULT_MEMORY_DIR,
+        help=f"Memory directory relative to the project root. Defaults to {DEFAULT_MEMORY_DIR}.",
+    )
+    parser.add_argument(
+        "--agent-file",
+        default=DEFAULT_AGENT_FILE,
+        help=f"Agent instruction file relative to the project root. Defaults to {DEFAULT_AGENT_FILE}.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Create memory files without creating or updating the agent instruction file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.project_root).expanduser().resolve()
+    if not root.exists():
+        raise SystemExit(f"Project root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"Project root is not a directory: {root}")
+
+    actions = write_missing_memory_files(root, args.memory_dir)
+    if not args.skip_agent:
+        actions.extend(upsert_agent_section(root, args.agent_file, args.memory_dir))
+
+    print(f"Initialized project memory in {root}")
+    for action in actions:
+        print(f"- {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/memories/scripts/init_project_memory.py
+++ b/skills/memories/scripts/init_project_memory.py
@@ -141,6 +141,7 @@ def resolve_inside(root: Path, relative_path: str, option_name: str) -> Path:
     candidate = Path(relative_path)
     if candidate.is_absolute():
         raise SystemExit(f"{option_name} must be relative to the project root")
+    reject_symlink_components(root, candidate, option_name)
 
     resolved = (root / candidate).resolve()
     try:
@@ -148,6 +149,31 @@ def resolve_inside(root: Path, relative_path: str, option_name: str) -> Path:
     except ValueError as exc:
         raise SystemExit(f"{option_name} must stay inside the project root") from exc
     return resolved
+
+
+def reject_symlink_components(root: Path, relative_path: Path, option_name: str) -> None:
+    current = root
+    for part in relative_path.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            try:
+                current.relative_to(root)
+            except ValueError:
+                return
+            continue
+
+        current = current / part
+        try:
+            display_path = current.relative_to(root)
+        except ValueError:
+            return
+
+        if current.is_symlink():
+            raise SystemExit(f"{option_name} must not contain symlinks: {display_path}")
+        if not current.exists():
+            return
 
 
 def ensure_regular_output_file(root: Path, path: Path) -> None:
@@ -197,6 +223,10 @@ def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[s
         return [f"created {path.relative_to(root)}"]
 
     original = path.read_text(encoding="utf-8")
+    if not original:
+        path.write_text(section, encoding="utf-8")
+        return [f"appended Project Memory section to {path.relative_to(root)}"]
+
     marker_pattern = re.compile(
         rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}\n?",
         re.DOTALL,
@@ -209,7 +239,7 @@ def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[s
         return [f"updated managed Project Memory block in {path.relative_to(root)}"]
 
     heading_pattern = re.compile(
-        r"^## Project Memor(?:y|ies)\n.*?(?=^## |\Z)",
+        r"^## Project Memor(?:y|ies)(?:\n|\Z).*?(?=^## |\Z)",
         re.DOTALL | re.MULTILINE,
     )
     if heading_pattern.search(original):

--- a/skills/memories/scripts/init_project_memory.py
+++ b/skills/memories/scripts/init_project_memory.py
@@ -33,9 +33,10 @@ def template_files(memory_dir: str) -> dict[str, str]:
 
             1. Read `index.md` before non-trivial work.
             2. Open only the memory files relevant to the current task.
-            3. Update memories when reusable project knowledge is discovered or corrected.
-            4. Keep entries concise, actionable, and easy to review in git.
-            5. Update `index.md` when adding, removing, renaming, or materially changing memory files.
+            3. Update memories when the user requests memory maintenance or when reusable project knowledge is a natural part of the current task.
+            4. Recommend a memory update instead of editing memory files when memory maintenance is outside the current task scope.
+            5. Keep entries concise, actionable, and easy to review in git.
+            6. Update `index.md` when adding, removing, renaming, or materially changing memory files.
 
             ## Default Files
 
@@ -123,7 +124,7 @@ def project_memory_section(memory_dir: str) -> str:
 
         Before non-trivial work, read `{memory_dir}/index.md` and then open only the memory files relevant to the task.
 
-        Update memories when you discover reusable project-specific knowledge that would help future agents. Do not store one-off task notes, temporary debugging details, raw chat logs, secrets, credentials, or conversation-specific context.
+        Update memories when the user requests memory maintenance or when reusable project-specific knowledge is a natural part of the current task. If memory maintenance is outside the current task scope, recommend the update instead of editing memory files. Do not store one-off task notes, temporary debugging details, raw chat logs, secrets, credentials, or conversation-specific context.
 
         When changing memories, keep entries concise and actionable. Update `{memory_dir}/index.md` when adding, removing, renaming, or materially changing memory files.
         {END_MARKER}
@@ -132,6 +133,11 @@ def project_memory_section(memory_dir: str) -> str:
 
 
 def resolve_inside(root: Path, relative_path: str, option_name: str) -> Path:
+    if not relative_path or not relative_path.strip():
+        raise SystemExit(f"{option_name} must not be empty")
+    if any(char in relative_path for char in ("\0", "\n", "\r")):
+        raise SystemExit(f"{option_name} must not contain control characters")
+
     candidate = Path(relative_path)
     if candidate.is_absolute():
         raise SystemExit(f"{option_name} must be relative to the project root")
@@ -144,13 +150,30 @@ def resolve_inside(root: Path, relative_path: str, option_name: str) -> Path:
     return resolved
 
 
+def ensure_regular_output_file(root: Path, path: Path) -> None:
+    try:
+        path.parent.resolve().relative_to(root)
+    except ValueError as exc:
+        raise SystemExit(f"Output path must stay inside the project root: {path}") from exc
+
+    if path.is_symlink():
+        raise SystemExit(f"Refusing to write through symlink: {path.relative_to(root)}")
+    if path.exists() and not path.is_file():
+        raise SystemExit(f"Output path is not a regular file: {path.relative_to(root)}")
+
+
 def write_missing_memory_files(root: Path, memory_dir: str) -> list[str]:
     target = resolve_inside(root, memory_dir, "--memory-dir")
+    if target == root:
+        raise SystemExit("--memory-dir must not be the project root")
+    if target.exists() and not target.is_dir():
+        raise SystemExit(f"--memory-dir exists but is not a directory: {target.relative_to(root)}")
     target.mkdir(parents=True, exist_ok=True)
 
     actions: list[str] = []
     for name, content in template_files(memory_dir).items():
         path = target / name
+        ensure_regular_output_file(root, path)
         if path.exists():
             actions.append(f"kept {path.relative_to(root)}")
             continue
@@ -163,6 +186,11 @@ def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[s
     path = resolve_inside(root, agent_file, "--agent-file")
     section = project_memory_section(memory_dir)
 
+    if path.exists() and not path.is_file():
+        raise SystemExit(f"--agent-file exists but is not a file: {path.relative_to(root)}")
+    if path.is_symlink():
+        raise SystemExit(f"Refusing to write through symlink: {path.relative_to(root)}")
+
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("# Agent Instructions\n\n" + section, encoding="utf-8")
@@ -173,8 +201,10 @@ def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[s
         rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}\n?",
         re.DOTALL,
     )
-    if marker_pattern.search(original):
-        updated = marker_pattern.sub(section, original)
+    marker_match = marker_pattern.search(original)
+    if marker_match:
+        trailing = marker_pattern.sub("", original[marker_match.end() :])
+        updated = original[: marker_match.start()] + section + trailing
         path.write_text(updated, encoding="utf-8")
         return [f"updated managed Project Memory block in {path.relative_to(root)}"]
 
@@ -183,9 +213,9 @@ def upsert_agent_section(root: Path, agent_file: str, memory_dir: str) -> list[s
         re.DOTALL | re.MULTILINE,
     )
     if heading_pattern.search(original):
-        updated = heading_pattern.sub(section, original)
-        path.write_text(updated, encoding="utf-8")
-        return [f"replaced existing Project Memory section in {path.relative_to(root)}"]
+        separator = "" if original.endswith("\n\n") else "\n" if original.endswith("\n") else "\n\n"
+        path.write_text(original + separator + section, encoding="utf-8")
+        return [f"appended managed Project Memory block to preserve existing section in {path.relative_to(root)}"]
 
     separator = "" if original.endswith("\n\n") else "\n" if original.endswith("\n") else "\n\n"
     path.write_text(original + separator + section, encoding="utf-8")


### PR DESCRIPTION
## Summary
Add a new memories skill that scaffolds project-local memory files and agent guidance for future reusable project context.

## Changes
- Add the memories skill definition and OpenAI UI metadata
- Add a Python scaffold script for .agents/memories files and AGENTS.md guidance
- Preserve existing memory files and hand-written Project Memory sections while tightening path and symlink safety

## Motivation
- Give projects a lightweight, repeatable way to initialize durable agent memory without storing one-off task context

## Testing
- PYTHONPYCACHEPREFIX=/private/tmp/python-cache python3 -m py_compile skills/memories/scripts/init_project_memory.py
- Parsed SKILL.md frontmatter with Ruby YAML
- Manually verified scaffold initialization, repeat runs, custom memory dirs, unmarked Project Memory preservation, duplicate managed block convergence, symlink rejection, empty/control-character path rejection, and directory agent-file rejection