### PR TITLE
docs(github-renovate-prs): add go-tapd cli preset repo

### DIFF
--- a/skills/github-renovate-prs/README.md
+++ b/skills/github-renovate-prs/README.md
@@ -36,6 +36,7 @@ When no repository is specified, the skill scans this preset set:
 
 - `go-fries/fries`
 - `go-tapd/tapd`
+- `go-tapd/cli`
 - `flc1125/go-twca`
 - `flc1125/go-cron`
 - `flc1125/go-gitlab-webhook`

--- a/skills/github-renovate-prs/SKILL.md
+++ b/skills/github-renovate-prs/SKILL.md
@@ -49,6 +49,7 @@ When the user does not specify a target repository, use this fixed preset set:
 
 - `go-fries/fries`
 - `go-tapd/tapd`
+- `go-tapd/cli`
 - `flc1125/go-twca`
 - `flc1125/go-cron`
 - `flc1125/go-gitlab-webhook`


### PR DESCRIPTION
## Summary
Add `go-tapd/cli` to the default repository set used by the github-renovate-prs skill.

## Changes
- Add `go-tapd/cli` to the preset list in `SKILL.md`
- Keep the README preset list in sync

## Motivation
- Include the go-tapd CLI repository in the default Renovate PR scan workflow

## Testing
- Not run; documentation-only skill preset update