### PR TITLE
fix(web): polish marketplace UI details

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -91,6 +91,14 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 text-center">
             <p className="text-[#111318] dark:text-white font-bold mb-2">Flc&apos;s Skills</p>
             <p className="text-[#687586] dark:text-[#aeb7c6] text-sm">Reusable agent workflows in a calm interface.</p>
+            <a
+              href="https://flc.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex rounded-full px-3 py-1.5 text-sm font-semibold text-[#178a70] transition-colors hover:bg-[#eef8f5] hover:text-[#111318] dark:text-[#8ddfc9] dark:hover:bg-white/10 dark:hover:text-white"
+            >
+              Creator homepage
+            </a>
             <p className="text-[#9aa4b2] dark:text-[#6f7887] text-xs mt-4">© 2026 Flc&apos;s Skills. All rights reserved.</p>
           </div>
         </footer>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -87,7 +87,7 @@ export default function RootLayout({
           </div>
         </header>
         <main>{children}</main>
-        <footer className="border-t border-black/5 py-12 mt-20 dark:border-white/10">
+        <footer className="border-t border-black/5 py-12 mt-10 dark:border-white/10">
           <div className="max-w-7xl mx-auto px-4 text-center">
             <p className="text-[#111318] dark:text-white font-bold mb-2">Flc&apos;s Skills</p>
             <p className="text-[#687586] dark:text-[#aeb7c6] text-sm">Reusable agent workflows in a calm interface.</p>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -91,15 +91,18 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 text-center">
             <p className="text-[#111318] dark:text-white font-bold mb-2">Flc&apos;s Skills</p>
             <p className="text-[#687586] dark:text-[#aeb7c6] text-sm">Reusable agent workflows in a calm interface.</p>
-            <a
-              href="https://flc.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-4 inline-flex rounded-full px-3 py-1.5 text-sm font-semibold text-[#178a70] transition-colors hover:bg-[#eef8f5] hover:text-[#111318] dark:text-[#8ddfc9] dark:hover:bg-white/10 dark:hover:text-white"
-            >
-              Creator homepage
-            </a>
-            <p className="text-[#9aa4b2] dark:text-[#6f7887] text-xs mt-4">© 2026 Flc&apos;s Skills. All rights reserved.</p>
+            <p className="text-[#9aa4b2] dark:text-[#6f7887] text-xs mt-4">
+              © 2026 Flc&apos;s Skills. Created by{' '}
+              <a
+                href="https://flc.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-[#178a70] transition-colors hover:text-[#111318] dark:text-[#8ddfc9] dark:hover:text-white"
+              >
+                Flc
+              </a>
+              . All rights reserved.
+            </p>
           </div>
         </footer>
       </body>

--- a/web/src/components/GithubNavLink.tsx
+++ b/web/src/components/GithubNavLink.tsx
@@ -18,7 +18,7 @@ export function GithubNavLink() {
           location: 'header',
         });
       }}
-      className="inline-flex h-9 items-center gap-2 rounded-full px-3 text-sm font-medium text-[#5f6673] transition-colors hover:bg-black hover:text-white dark:text-[#c6ccd8] dark:hover:bg-white dark:hover:text-black"
+      className="inline-flex h-9 items-center gap-2 rounded-full px-3 text-sm font-medium text-[#5f6673] transition-colors hover:bg-[#eef8f5] hover:text-black dark:text-[#c6ccd8] dark:hover:bg-white/10 dark:hover:text-white"
     >
       <Icons.Github size={15} />
       <span className="hidden sm:inline">GitHub</span>

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -155,7 +155,7 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
 
   return (
     <div className="relative mx-auto max-w-7xl px-4 pb-20 pt-0 sm:px-6 lg:px-8">
-      <section className="relative overflow-hidden px-2 py-14 sm:px-6 sm:py-20">
+      <section className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden px-6 py-14 sm:px-6 sm:py-20">
         <div className="pointer-events-none absolute left-1/2 top-2 h-72 w-[52rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_45%_45%,rgba(141,223,201,0.32),rgba(198,216,255,0.24)_42%,rgba(199,185,255,0.16)_58%,transparent_74%)] blur-3xl dark:opacity-50" />
         <div className="pointer-events-none absolute left-[12%] top-32 h-28 w-28 rounded-full bg-[#8ddfc9]/18 blur-2xl" />
         <div className="pointer-events-none absolute right-[14%] top-44 h-32 w-32 rounded-full bg-[#c6d8ff]/22 blur-2xl" />

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -187,11 +187,11 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
 
             <div className="relative">
               <div className="pointer-events-none absolute inset-x-8 -top-5 h-16 rounded-full bg-[#8ddfc9]/20 blur-2xl dark:bg-[#8ddfc9]/12" />
-              <Search className="absolute left-5 top-1/2 -translate-y-1/2 text-[#7f8a9a]" size={20} />
+              <Search className="pointer-events-none absolute left-5 top-1/2 z-10 -translate-y-1/2 text-[#7f8a9a]" size={20} />
               <input
                 type="text"
                 placeholder="Search skills..."
-                className="relative h-16 w-full rounded-[1.35rem] bg-white/82 pl-14 pr-5 text-base font-medium text-[#15171c] outline-none shadow-[0_30px_90px_-58px_rgba(15,23,42,0.55)] backdrop-blur transition placeholder:text-[#8a94a3] focus:ring-4 focus:ring-[#8ddfc9]/25 dark:bg-white/[0.08] dark:text-white"
+                className="relative z-0 h-16 w-full rounded-[1.35rem] bg-white/82 pl-14 pr-5 text-base font-medium text-[#15171c] outline-none shadow-[0_30px_90px_-58px_rgba(15,23,42,0.55)] backdrop-blur transition placeholder:text-[#8a94a3] focus:ring-4 focus:ring-[#8ddfc9]/25 dark:bg-white/[0.08] dark:text-white"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -154,7 +154,7 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
   };
 
   return (
-    <div className="relative mx-auto max-w-7xl px-4 pb-20 pt-0 sm:px-6 lg:px-8">
+    <div className="relative mx-auto max-w-7xl px-4 pb-8 pt-0 sm:px-6 lg:px-8">
       <section className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden px-6 py-14 sm:px-6 sm:py-20">
         <div className="pointer-events-none absolute left-1/2 top-2 h-72 w-[52rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_45%_45%,rgba(141,223,201,0.32),rgba(198,216,255,0.24)_42%,rgba(199,185,255,0.16)_58%,transparent_74%)] blur-3xl dark:opacity-50" />
         <div className="pointer-events-none absolute left-[12%] top-32 h-28 w-28 rounded-full bg-[#8ddfc9]/18 blur-2xl" />

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -203,11 +203,6 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
       <div className="relative mx-auto -mt-8 mb-12 h-16 max-w-5xl" aria-hidden="true">
         <div className="absolute inset-x-8 top-1/2 h-px bg-gradient-to-r from-transparent via-[#91dcca]/50 to-transparent dark:via-white/18" />
         <div className="absolute left-1/2 top-1/2 h-12 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[linear-gradient(90deg,rgba(141,223,201,0.26),rgba(198,216,255,0.3),rgba(199,185,255,0.22))] blur-2xl" />
-        <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-full bg-white/56 px-3 py-2 shadow-[0_18px_60px_-42px_rgba(15,23,42,0.6)] backdrop-blur dark:bg-white/[0.07]">
-          <span className="h-1.5 w-8 rounded-full bg-[#8ddfc9]/85 shadow-[0_0_18px_rgba(141,223,201,0.45)]" />
-          <span className="h-1.5 w-14 rounded-full bg-[#c6d8ff]/90 shadow-[0_0_18px_rgba(198,216,255,0.45)]" />
-          <span className="h-1.5 w-8 rounded-full bg-[#c7b9ff]/85 shadow-[0_0_18px_rgba(199,185,255,0.42)]" />
-        </div>
       </div>
 
       <section className="mt-0">

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -79,7 +79,7 @@ export function SkillCard({ skill, position, onClick }: SkillCardProps) {
 
       <div className="mb-3">
         <div className="min-w-0">
-          <h3 className="text-[1.05rem] font-bold leading-tight text-[#14161b] transition-colors group-hover:text-black dark:text-white">
+          <h3 className="text-[1.05rem] font-bold leading-tight text-[#14161b] transition-colors group-hover:text-black dark:text-white dark:group-hover:text-white">
             {displayName}
           </h3>
           <div className="mt-1">

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -142,17 +142,19 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
             >
               <Dialog.Panel className="w-full max-w-4xl transform overflow-hidden rounded-[2rem] border border-black/10 bg-[#fbfcfd] p-0 shadow-[0_42px_120px_-52px_rgba(15,23,42,0.75)] transition-all dark:border-white/10 dark:bg-[#151821]">
                 <div className="h-2 bg-[linear-gradient(90deg,#8ddfc9,#d7f6a7,#c6d8ff,#d8ccff)]" />
-                <div className="flex items-center justify-between gap-5 border-b border-black/5 bg-white/70 px-5 py-5 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04] sm:px-7">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#e7fbf4] text-[#178a70] dark:bg-emerald-300/10 dark:text-[#8ddfc9]">
-                      <Terminal size={20} />
-                    </div>
-                    <div className="min-w-0">
-                      <Dialog.Title as="h3" className="text-xl font-black leading-tight text-[#111318] dark:text-white">
+                <div className="flex items-start justify-between gap-3 border-b border-black/5 bg-white/70 px-5 py-5 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04] sm:items-center sm:gap-5 sm:px-7">
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#e7fbf4] text-[#178a70] dark:bg-emerald-300/10 dark:text-[#8ddfc9]">
+                        <Terminal size={20} />
+                      </div>
+                      <Dialog.Title as="h3" className="min-w-0 text-xl font-black leading-tight text-[#111318] dark:text-white">
                         {displayName}
                       </Dialog.Title>
+                    </div>
+                    <div className="min-w-0 pl-14">
                       {skill ? (
-                        <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px] font-semibold text-[#7a8493] dark:text-[#aeb7c6]">
+                        <div className="mt-2 flex min-w-0 flex-wrap items-center gap-2 text-[12px] font-semibold text-[#7a8493] dark:text-[#aeb7c6]">
                           <span className="inline-flex items-center rounded-full bg-[#edf7f4] px-2.5 py-1 text-[10px] lowercase text-[#2d8c75] dark:bg-emerald-300/10 dark:text-[#8ddfc9]">
                             {skill.name}
                           </span>
@@ -179,7 +181,7 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
                                 target: 'github_skill_source',
                               });
                             }}
-                            className="inline-flex items-center gap-1.5 rounded-full bg-black px-2.5 py-1 text-white transition-colors hover:bg-[#27302d] dark:bg-white dark:text-black dark:hover:bg-[#dbe5e1]"
+                            className="inline-flex shrink-0 basis-full items-center justify-center gap-1.5 rounded-full bg-black px-2.5 py-1 text-white transition-colors hover:bg-[#27302d] dark:bg-white dark:text-black dark:hover:bg-[#dbe5e1] sm:basis-auto"
                             title="View source file on GitHub"
                           >
                             <ExternalLink size={12} className="flex-shrink-0" />
@@ -189,7 +191,7 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
                       ) : null}
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     <button
                       onClick={onClose}
                       className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-[#687586] shadow-sm ring-1 ring-black/5 transition hover:bg-[#eef8f5] hover:text-black focus:outline-none focus:ring-2 focus:ring-[#8ddfc9]/60 dark:bg-white/[0.08] dark:text-[#aeb7c6] dark:ring-white/10 dark:hover:bg-white/[0.14] dark:hover:text-white"


### PR DESCRIPTION
## Summary
Polish the marketplace UI across the hero, cards, modal header, nav controls, and footer attribution.

## Changes
- Fix search icon layering and dark-mode card title hover color
- Extend the hero background on narrow screens and remove the center divider marker
- Tighten footer spacing and add inline creator attribution linking to flc.io
- Align GitHub nav hover states with the theme toggle
- Stabilize the skill modal header layout on narrow screens

## Motivation
- These tweaks address visual inconsistencies found during browser review across light/dark themes and responsive widths.

## Testing
- Manually verified the marketplace in the in-app browser
- Checked responsive modal header at 360, 393, 430, and 540 px widths
- Checked mobile hero background at 390, 540, 768, and 1024 px widths
- Ran npm run lint; it currently fails before linting changes because ESLint 10 errors while loading eslint-plugin-react's react/display-name rule