### PR TITLE
feat(plugin): add Codex plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "skills",
+  "version": "0.6.0",
+  "description": "A curated collection of reusable Codex skills maintained by Flc.",
+  "author": {
+    "name": "Flc",
+    "url": "https://github.com/flc1125"
+  },
+  "homepage": "https://skills.flc.io",
+  "repository": "https://github.com/flc1125/skills",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "skills",
+    "agents",
+    "workflows"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Flc's Skills",
+    "shortDescription": "Reusable Codex skills for agent workflows.",
+    "longDescription": "Flc's Skills packages reusable Codex workflows, review helpers, GitHub and GitLab operations, knowledge tools, and orchestration patterns from this repository.",
+    "developerName": "Flc",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills",
+      "Workflow Automation",
+      "Code Review"
+    ],
+    "websiteURL": "https://skills.flc.io",
+    "composerIcon": "./web/public/favicon.svg",
+    "logo": "./web/public/favicon.svg",
+    "defaultPrompt": [
+      "Use a skill from Flc's Skills.",
+      "Find the right workflow skill for this task.",
+      "Help me operate this repository with a reusable skill."
+    ],
+    "brandColor": "#111318"
+  }
+}


### PR DESCRIPTION
## Summary
Add a Codex plugin manifest so this repository can be consumed as a plugin-backed collection of reusable skills.

## Changes
- Add `.codex-plugin/plugin.json` pointing at the existing `./skills/` directory
- Set plugin metadata to version `0.6.0` with repository, homepage, display, prompt, and icon fields
- Reuse the existing marketplace favicon for the plugin composer icon and logo

## Motivation
- The repository already contains installable skills, and the manifest lets Codex discover them through the plugin system.

## Testing
- `python3 -m json.tool .codex-plugin/plugin.json`
- `PYTHONPATH=/private/tmp/codex-plugin-validator-yaml python3 /Users/flc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/flc/data/www/open-source/flc1125/skills`