### PR TITLE
Add marketplace plugin manifest for skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "flc-skills",
+  "interface": {
+    "displayName": "Flc's Skills"
+  },
+  "plugins": [
+    {
+      "name": "skills",
+      "source": {
+        "source": "url",
+        "url": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.agents/plugins/marketplace.json` for the `flc-skills` marketplace entry
- Expose the `skills` plugin with install availability and on-install authentication

## Testing
- Not run (not requested)