### PR TITLE
feat(pr-mr): add breaking change guidance

### DIFF
--- a/skills/github-create-pr/README.md
+++ b/skills/github-create-pr/README.md
@@ -13,6 +13,7 @@ npx skills add https://github.com/flc1125/skills --skill github-create-pr
 - Check branch status and PR base
 - Analyze commits and diff
 - Draft a clear PR title and body
+- Document breaking changes, before-and-after comparisons, and migration steps when needed
 - Create or update a PR with `gh`
 - Add reviewers when needed
 
@@ -25,6 +26,7 @@ github-create-pr/
 ├── agents/
 │   └── openai.yaml
 └── references/
+    ├── breaking-change-conventions.md
     └── pr-body-conventions.md
 ```
 

--- a/skills/github-create-pr/SKILL.md
+++ b/skills/github-create-pr/SKILL.md
@@ -70,6 +70,17 @@ Extract:
 - risks, migrations, or rollout notes only when they materially affect review
 - any issue references already implied by commits or branch naming
 
+Build a change-impact inventory before drafting:
+
+- new or changed user-facing capabilities
+- removed, renamed, or changed public APIs, packages, commands, configuration, or dependencies
+- behavior changes involving defaults, errors, context, cancellation, panic, ordering, timeouts, retries, persistence, or lifecycle
+- actions required from downstream users to upgrade safely
+- important contracts or scope boundaries that remain unchanged
+- validation actually performed, including material checks that could not be run
+
+Use the base-to-head diff, current code, and tests as the primary evidence. Treat commit messages, plans, and earlier design notes as secondary context because they may describe ideas that were later revised or removed.
+
 Do not write the PR body until the scope is understood.
 
 ### 3. Write the PR title
@@ -82,11 +93,15 @@ If the repository uses conventional-commit style titles, follow that pattern:
 - `fix(api): handle null response`
 - `refactor(auth): extract validation logic`
 
+Use the conventional-commit `!` marker when the change is actually incompatible, for example `refactor(auth)!: replace token storage`. Do not use `!` merely because a diff is large or heavily refactored.
+
 If no convention is visible, use a plain imperative summary.
 
 ### 4. Write the PR body
 
 Use the default PR body conventions in [references/pr-body-conventions.md](references/pr-body-conventions.md) unless the user explicitly asks for another format.
+
+When the change is incompatible, or the user asks for breaking changes, before-and-after comparisons, upgrade notes, or migration guidance, also read and apply [references/breaking-change-conventions.md](references/breaking-change-conventions.md). Add only the sections supported by the actual change; do not emit empty headings.
 
 ### 5. Sanitize public PR content
 
@@ -152,6 +167,9 @@ If the user asks to open the PR directly, still summarize the final title, body,
 - Prefer draft PRs when work is incomplete, risky, or waiting on feedback.
 - Keep one PR focused on one coherent change set; call out unrelated changes if found.
 - Explain behavior changes, migrations, and follow-up work only when they materially affect review.
+- Determine compatibility from required downstream action, not from diff size, commit wording, or whether the implementation is called a refactor.
+- Give every removed or renamed public surface a replacement, migration action, or explicit statement that no direct replacement exists.
+- State preserved contracts when reviewers could otherwise mistake a scoped refactor for a broader behavior change.
 - Treat PR titles, bodies, comments, and notes as public. Strip local debugging details and machine-specific paths before publishing.
 - Use issue-closing syntax only when the linkage is clear and intended.
 

--- a/skills/github-create-pr/references/breaking-change-conventions.md
+++ b/skills/github-create-pr/references/breaking-change-conventions.md
@@ -1,0 +1,126 @@
+# Breaking Change and Migration Conventions
+
+Use this reference when a pull request is incompatible, or when the user asks for breaking changes, before-and-after comparisons, upgrade notes, or migration guidance.
+
+## Identify Breaking Changes
+
+Treat a change as breaking when downstream users must change code, configuration, data, deployment, or operating assumptions to upgrade safely.
+
+Common examples include:
+
+- removing or renaming public functions, types, fields, constants, packages, modules, commands, or flags
+- changing function signatures, interfaces, return values, error types, module paths, imports, configuration keys, or environment variables
+- changing defaults or behavior involving context, cancellation, panic, ordering, timeouts, retries, persistence, serialization, lifecycle, or concurrency
+- changing schemas, wire formats, stored data, deployment requirements, or supported runtime versions
+- removing an extension point without a direct replacement
+
+The following are usually not breaking by themselves:
+
+- internal refactors that preserve observable behavior
+- documentation or test-only changes
+- compatible additive APIs
+- performance improvements that preserve contracts
+- large diffs with no required downstream action
+
+Do not infer compatibility from a commit title alone. Verify it against the base-to-head diff, current public surface, tests, and documented behavior.
+
+## Adaptive Template
+
+Start with the default PR body and add only the sections supported by the change:
+
+```markdown
+## Summary
+<!-- 1-2 sentences describing the outcome -->
+
+## Changes
+- <!-- new capabilities and meaningful behavior -->
+
+## Motivation
+- <!-- why the change is needed -->
+
+## Breaking Changes
+- <!-- removed or changed public surfaces -->
+- <!-- incompatible behavior changes -->
+
+## Before and After
+<!-- focused code examples or an old-to-new mapping table -->
+
+## Migration
+1. <!-- ordered upgrade action -->
+2. <!-- ordered upgrade action -->
+
+## Behavior and Compatibility
+- <!-- important semantic changes -->
+- <!-- contracts or scope boundaries that remain unchanged -->
+
+## Testing
+- <!-- commands or checks actually completed -->
+```
+
+Omit `Breaking Changes`, `Before and After`, `Migration`, or `Behavior and Compatibility` when the section would be empty or add no material reviewer value.
+
+## Write Each Section Deliberately
+
+### Changes
+
+- Describe capabilities, public API changes, and meaningful runtime behavior.
+- Group related changes instead of narrating individual files or commits.
+- Distinguish additions, removals, and changed behavior when the scope is large.
+
+### Breaking Changes
+
+- Separate public surface changes from behavior changes when both exist.
+- Name the affected API, configuration, protocol, or runtime contract precisely.
+- Explain which downstream users are affected and what action they must take.
+- Do not hide breaking behavior under a generic `Changes` bullet.
+
+### Before and After
+
+- Prefer a compact mapping table when several APIs have direct replacements.
+- Use code examples for the primary migration path or when behavior cannot be explained clearly in a table.
+- Include required imports or surrounding declarations when needed for the example to be self-contained.
+- Keep examples aligned with the final code, not an earlier design proposal.
+
+Example mapping:
+
+```markdown
+| Before | After |
+| --- | --- |
+| `oldpkg.Run(...)` | `newpkg.Do(...)` |
+| `WithPolicy(...)` | `WithMaxAttempts(...)` and `WithBackoff(...)` |
+| `legacy.Codec` | `legacy.Codec{}` |
+```
+
+### Migration
+
+- Provide ordered, actionable upgrade steps.
+- Cover import or module path changes, replacements, configuration updates, and required data or deployment actions.
+- Call out changed defaults and semantics even when the new code looks similar.
+- State explicitly when an API has no direct replacement.
+- Distinguish required migration actions from optional follow-up improvements.
+- Keep migration history in the PR body unless the user or repository convention separately requires documentation changes.
+
+### Behavior and Compatibility
+
+- Explain error, context, cancellation, panic, timeout, retry, ordering, concurrency, persistence, or lifecycle semantics that affect reviewers or users.
+- State important unchanged contracts when a scoped refactor could otherwise look broader than it is.
+- Use this section for operational risk and compatibility boundaries, not implementation trivia.
+
+### Testing
+
+- State only commands and checks that actually completed.
+- Include meaningful coverage, race, build, lint, migration, or compatibility validation when relevant.
+- Mention skipped or blocked validation with the reason when it affects confidence.
+- Summarize results instead of pasting machine-specific output.
+
+## Completeness Check
+
+Before publishing the PR body, verify:
+
+- every removed or renamed public surface has a replacement, migration action, or explicit no-replacement statement
+- every incompatible behavior change explains its downstream impact
+- before-and-after examples match the final diff and are internally coherent
+- migration steps include required imports, configuration, data, or deployment changes
+- preserved contracts are stated when they materially narrow the review scope
+- no section claims documentation, tests, or validation that did not actually change or run
+- no local paths, temporary plan files, credentials, hosts, or machine-specific details are exposed

--- a/skills/github-create-pr/references/pr-body-conventions.md
+++ b/skills/github-create-pr/references/pr-body-conventions.md
@@ -4,6 +4,8 @@ Use this file when drafting the default GitHub pull request body for this skill.
 
 Keep the PR body simple, clear, and easy to scan. Prefer short sections, concrete bullets, and direct wording that helps reviewers understand the change quickly.
 
+Use the default template for focused, compatible changes. When the change is incompatible, or the user explicitly requests breaking changes, before-and-after comparisons, upgrade notes, or migration guidance, use the additional rules and adaptive template in [breaking-change-conventions.md](breaking-change-conventions.md).
+
 ## Default Template
 
 ```markdown
@@ -24,12 +26,15 @@ Keep the PR body simple, clear, and easy to scan. Prefer short sections, concret
 ## Writing Rules
 
 - Keep the body concise and reviewer-focused.
-- Prefer concrete changes over line-by-line diff summaries.
+- Describe public capabilities and meaningful behavior, not a file-by-file diff narration.
+- Base the body on the final base-to-head diff, current code, and tests; do not publish stale ideas from plans or earlier discussion.
 - State only the testing that actually happened.
+- Mention skipped or blocked validation only when it materially affects review confidence.
 - Do not include secrets, credentials, local environment details, absolute local paths, or other sensitive information in the PR body.
 - Use repository-relative paths only when they help reviewers locate changed source files.
 - Summarize local debugging and command output instead of publishing machine-specific paths such as `/Users/...`, `/tmp/...`, cache directories, generated artifact locations, hostnames, usernames, or local-only ports.
-- Add `Breaking Changes` only when the change is actually breaking.
+- Add optional sections only when they contain material reviewer information; never emit empty headings.
+- Add `Breaking Changes` only when downstream users must change code, configuration, data, deployment, or operating assumptions.
 - Add `Notes` only for important reviewer context, limitations, or follow-up items.
 
 ## Example

--- a/skills/gitlab-create-mr/README.md
+++ b/skills/gitlab-create-mr/README.md
@@ -14,6 +14,7 @@ npx skills add https://github.com/flc1125/skills --skill gitlab-create-mr
 - Detect the correct GitLab host for GitLab.com or self-managed instances
 - Analyze commits and diff before drafting the MR
 - Draft a clear merge request title and description
+- Document breaking changes, before-and-after comparisons, and migration steps when needed
 - Create the merge request with `glab`
 - Reuse a local MR body conventions document for consistent descriptions
 
@@ -26,6 +27,7 @@ gitlab-create-mr/
 ├── agents/
 │   └── openai.yaml
 └── references/
+    ├── breaking-change-conventions.md
     ├── mr-body-conventions.md
     └── verified-commands.md
 ```

--- a/skills/gitlab-create-mr/SKILL.md
+++ b/skills/gitlab-create-mr/SKILL.md
@@ -70,6 +70,17 @@ Extract:
 - risks, migrations, or rollout notes only when they materially affect review
 - any issue references already implied by commits or branch naming
 
+Build a change-impact inventory before drafting:
+
+- new or changed user-facing capabilities
+- removed, renamed, or changed public APIs, packages, commands, configuration, or dependencies
+- behavior changes involving defaults, errors, context, cancellation, panic, ordering, timeouts, retries, persistence, or lifecycle
+- actions required from downstream users to upgrade safely
+- important contracts or scope boundaries that remain unchanged
+- validation actually performed, including material checks that could not be run
+
+Use the base-to-head diff, current code, and tests as the primary evidence. Treat commit messages, plans, and earlier design notes as secondary context because they may describe ideas that were later revised or removed.
+
 Do not write the merge request until the scope is understood.
 
 ### 3. Write the merge request title
@@ -82,11 +93,15 @@ If the repository uses conventional-commit style titles, follow that pattern:
 - `fix(api): handle null response`
 - `refactor(auth): extract validation logic`
 
+Use the conventional-commit `!` marker when the change is actually incompatible, for example `refactor(auth)!: replace token storage`. Do not use `!` merely because a diff is large or heavily refactored.
+
 If no convention is visible, use a plain imperative summary.
 
 ### 4. Write the merge request description
 
-Use the default MR Body conventions in [references/mr-body-conventions.md](references/mr-body-conventions.md) unless the user explicitly asks for another format.
+Use the default MR body conventions in [references/mr-body-conventions.md](references/mr-body-conventions.md) unless the user explicitly asks for another format.
+
+When the change is incompatible, or the user asks for breaking changes, before-and-after comparisons, upgrade notes, or migration guidance, also read and apply [references/breaking-change-conventions.md](references/breaking-change-conventions.md). Add only the sections supported by the actual change; do not emit empty headings.
 
 ### 5. Create or update the merge request
 
@@ -160,6 +175,10 @@ If the user asks to open the merge request directly, still summarize the final t
 - Prefer draft merge requests when work is incomplete, risky, or waiting on feedback.
 - Keep one merge request focused on one coherent change set.
 - Explain behavior changes, migrations, and follow-up work only when they materially affect review.
+- Determine compatibility from required downstream action, not from diff size, commit wording, or whether the implementation is called a refactor.
+- Give every removed or renamed public surface a replacement, migration action, or explicit statement that no direct replacement exists.
+- State preserved contracts when reviewers could otherwise mistake a scoped refactor for a broader behavior change.
+- Treat merge request titles, descriptions, comments, and notes as public. Strip local debugging details and machine-specific paths before publishing.
 - Use issue-closing syntax only when the linkage is clear and intended for GitLab.
 
 ## Red Flags

--- a/skills/gitlab-create-mr/references/breaking-change-conventions.md
+++ b/skills/gitlab-create-mr/references/breaking-change-conventions.md
@@ -1,0 +1,126 @@
+# Breaking Change and Migration Conventions
+
+Use this reference when a merge request is incompatible, or when the user asks for breaking changes, before-and-after comparisons, upgrade notes, or migration guidance.
+
+## Identify Breaking Changes
+
+Treat a change as breaking when downstream users must change code, configuration, data, deployment, or operating assumptions to upgrade safely.
+
+Common examples include:
+
+- removing or renaming public functions, types, fields, constants, packages, modules, commands, or flags
+- changing function signatures, interfaces, return values, error types, module paths, imports, configuration keys, or environment variables
+- changing defaults or behavior involving context, cancellation, panic, ordering, timeouts, retries, persistence, serialization, lifecycle, or concurrency
+- changing schemas, wire formats, stored data, deployment requirements, or supported runtime versions
+- removing an extension point without a direct replacement
+
+The following are usually not breaking by themselves:
+
+- internal refactors that preserve observable behavior
+- documentation or test-only changes
+- compatible additive APIs
+- performance improvements that preserve contracts
+- large diffs with no required downstream action
+
+Do not infer compatibility from a commit title alone. Verify it against the base-to-head diff, current public surface, tests, and documented behavior.
+
+## Adaptive Template
+
+Start with the default MR body and add only the sections supported by the change:
+
+```markdown
+## Summary
+<!-- 1-2 sentences describing the outcome -->
+
+## Changes
+- <!-- new capabilities and meaningful behavior -->
+
+## Motivation
+- <!-- why the change is needed -->
+
+## Breaking Changes
+- <!-- removed or changed public surfaces -->
+- <!-- incompatible behavior changes -->
+
+## Before and After
+<!-- focused code examples or an old-to-new mapping table -->
+
+## Migration
+1. <!-- ordered upgrade action -->
+2. <!-- ordered upgrade action -->
+
+## Behavior and Compatibility
+- <!-- important semantic changes -->
+- <!-- contracts or scope boundaries that remain unchanged -->
+
+## Testing
+- <!-- commands or checks actually completed -->
+```
+
+Omit `Breaking Changes`, `Before and After`, `Migration`, or `Behavior and Compatibility` when the section would be empty or add no material reviewer value.
+
+## Write Each Section Deliberately
+
+### Changes
+
+- Describe capabilities, public API changes, and meaningful runtime behavior.
+- Group related changes instead of narrating individual files or commits.
+- Distinguish additions, removals, and changed behavior when the scope is large.
+
+### Breaking Changes
+
+- Separate public surface changes from behavior changes when both exist.
+- Name the affected API, configuration, protocol, or runtime contract precisely.
+- Explain which downstream users are affected and what action they must take.
+- Do not hide breaking behavior under a generic `Changes` bullet.
+
+### Before and After
+
+- Prefer a compact mapping table when several APIs have direct replacements.
+- Use code examples for the primary migration path or when behavior cannot be explained clearly in a table.
+- Include required imports or surrounding declarations when needed for the example to be self-contained.
+- Keep examples aligned with the final code, not an earlier design proposal.
+
+Example mapping:
+
+```markdown
+| Before | After |
+| --- | --- |
+| `oldpkg.Run(...)` | `newpkg.Do(...)` |
+| `WithPolicy(...)` | `WithMaxAttempts(...)` and `WithBackoff(...)` |
+| `legacy.Codec` | `legacy.Codec{}` |
+```
+
+### Migration
+
+- Provide ordered, actionable upgrade steps.
+- Cover import or module path changes, replacements, configuration updates, and required data or deployment actions.
+- Call out changed defaults and semantics even when the new code looks similar.
+- State explicitly when an API has no direct replacement.
+- Distinguish required migration actions from optional follow-up improvements.
+- Keep migration history in the MR body unless the user or repository convention separately requires documentation changes.
+
+### Behavior and Compatibility
+
+- Explain error, context, cancellation, panic, timeout, retry, ordering, concurrency, persistence, or lifecycle semantics that affect reviewers or users.
+- State important unchanged contracts when a scoped refactor could otherwise look broader than it is.
+- Use this section for operational risk and compatibility boundaries, not implementation trivia.
+
+### Testing
+
+- State only commands and checks that actually completed.
+- Include meaningful coverage, race, build, lint, migration, or compatibility validation when relevant.
+- Mention skipped or blocked validation with the reason when it affects confidence.
+- Summarize results instead of pasting machine-specific output.
+
+## Completeness Check
+
+Before publishing the MR body, verify:
+
+- every removed or renamed public surface has a replacement, migration action, or explicit no-replacement statement
+- every incompatible behavior change explains its downstream impact
+- before-and-after examples match the final diff and are internally coherent
+- migration steps include required imports, configuration, data, or deployment changes
+- preserved contracts are stated when they materially narrow the review scope
+- no section claims documentation, tests, or validation that did not actually change or run
+- no local paths, temporary plan files, credentials, hosts, or machine-specific details are exposed

--- a/skills/gitlab-create-mr/references/mr-body-conventions.md
+++ b/skills/gitlab-create-mr/references/mr-body-conventions.md
@@ -4,6 +4,8 @@ Use this file when drafting the default GitLab merge request description for thi
 
 Keep the MR body simple, clear, and easy to scan. Prefer short sections, concrete bullets, and direct wording that helps reviewers understand the change quickly.
 
+Use the default template for focused, compatible changes. When the change is incompatible, or the user explicitly requests breaking changes, before-and-after comparisons, upgrade notes, or migration guidance, use the additional rules and adaptive template in [breaking-change-conventions.md](breaking-change-conventions.md).
+
 ## Default Template
 
 ```markdown
@@ -24,10 +26,15 @@ Keep the MR body simple, clear, and easy to scan. Prefer short sections, concret
 ## Writing Rules
 
 - Keep the body concise and reviewer-focused.
-- Prefer concrete changes over line-by-line diff summaries.
+- Describe public capabilities and meaningful behavior, not a file-by-file diff narration.
+- Base the body on the final base-to-head diff, current code, and tests; do not publish stale ideas from plans or earlier discussion.
 - State only the testing that actually happened.
-- Do not include secrets, credentials, local environment details, or other sensitive information in the MR body.
-- Add `Breaking Changes` only when the change is actually breaking.
+- Mention skipped or blocked validation only when it materially affects review confidence.
+- Do not include secrets, credentials, local environment details, absolute local paths, or other sensitive information in the MR body.
+- Use repository-relative paths only when they help reviewers locate changed source files.
+- Summarize local debugging and command output instead of publishing machine-specific paths such as `/Users/...`, `/tmp/...`, cache directories, generated artifact locations, hostnames, usernames, or local-only ports.
+- Add optional sections only when they contain material reviewer information; never emit empty headings.
+- Add `Breaking Changes` only when downstream users must change code, configuration, data, deployment, or operating assumptions.
 - Add `Notes` only for important reviewer context, limitations, or follow-up items.
 
 ## Example


### PR DESCRIPTION
## Summary
Add compatibility-aware authoring guidance to the GitHub PR and GitLab MR skills so incompatible changes receive clear impact, comparison, and migration documentation.

## Changes
- Add change-impact inventories and compatibility decision rules to both skills
- Add adaptive breaking-change references covering before-and-after examples, migration steps, preserved contracts, and completeness checks
- Update the default body conventions and READMEs to route incompatible changes through the new guidance while keeping compatible changes concise

## Motivation
- Help agents distinguish genuinely breaking changes from large but compatible diffs and give downstream users actionable upgrade guidance

## Testing
- `git diff --check origin/main...HEAD`
- `npx next build --webpack`
- Generated marketplace skill data and manually verified the two affected skill API entries
- `npm run lint` (blocked by the current ESLint 10 and plugin compatibility mismatch)
