### PR TITLE
feat(create-plan): add repository-aware planning skill

### DIFF
--- a/skills/create-plan/SKILL.md
+++ b/skills/create-plan/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: create-plan
 description: Create and maintain repository-aware technical plans, implementation plans, refactor proposals, design drafts, and migration plans. Use when Codex is asked to investigate a codebase and propose a solution before implementation; write or update a durable plan file; produce a 方案、实施计划或重构计划; split engineering work into phases or pull requests; document scope, non-goals, API and behavior decisions, breaking changes, migrations, risks, testing, or validation; or transition a plan through draft, planned, in-progress, blocked, and completed states.
+metadata:
+  name: Create Plan
+  description: Create and maintain repository-aware technical plans, design proposals, and migration guides.
+  author: FLC
+  created: "2026-07-13T16:14:03Z"
 ---
 
 # Create Plan

--- a/skills/create-plan/SKILL.md
+++ b/skills/create-plan/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: create-plan
+description: Create and maintain repository-aware technical plans, implementation plans, refactor proposals, design drafts, and migration plans. Use when Codex is asked to investigate a codebase and propose a solution before implementation; write or update a durable plan file; produce a 方案、实施计划或重构计划; split engineering work into phases or pull requests; document scope, non-goals, API and behavior decisions, breaking changes, migrations, risks, testing, or validation; or transition a plan through draft, planned, in-progress, blocked, and completed states.
+---
+
+# Create Plan
+
+Create evidence-backed engineering plans that another agent can execute without reconstructing the design from conversation history.
+
+## Operating Mode
+
+Act as a repository-aware technical planner.
+
+Prioritize:
+
+- verified repository facts over recalled conversation details
+- explicit scope and non-goals over broad aspirations
+- decisions and executable steps over generic advice
+- validation tied to repository commands and risks
+- adaptive structure over one mandatory large template
+
+Do not implement runtime changes while the user is still asking for evaluation or a plan. Do not create a branch, commit, pull request, or plan file unless the user requested that action or repository instructions explicitly require the artifact.
+
+## Workflow
+
+### 1. Determine the deliverable
+
+Distinguish between:
+
+- **Conversational proposal**: The user asks to assess, compare, or "先给方案". Return the proposal in chat and do not create a file.
+- **Durable plan**: The user explicitly asks to create, write, record, or update a plan document. Locate the repository plan directory and write the artifact.
+- **Lifecycle update**: The user asks to start, block, resume, or complete an existing plan. Update both its contents and status-bearing filename.
+
+Ask a question only when a missing decision would materially change scope or architecture. Otherwise make a bounded assumption and label it.
+
+### 2. Discover repository conventions
+
+Before drafting:
+
+1. Read applicable `AGENTS.md` files and repository instructions.
+2. Locate existing plan and memory directories.
+3. Include hidden and ignored plans in discovery. Prefer:
+
+   ```bash
+   rg --files --hidden --no-ignore | rg '(^|/)(plans|plan)/|plan.*\.md$'
+   ```
+
+4. Inspect representative plans with the same task shape and status.
+5. Read the relevant source, tests, dependency files, and build commands.
+6. Check repository history or issues only when they affect the plan.
+
+Treat current code and tests as primary evidence. Treat prior plans and conversation as secondary context because they may be stale.
+
+When writing or updating a plan file, read [references/plan-conventions.md](references/plan-conventions.md) completely before editing.
+
+### 3. Frame the problem
+
+Establish:
+
+- current behavior and evidence
+- concrete objective and completion criteria
+- affected modules, public surfaces, and users
+- constraints and dependencies
+- explicit non-goals
+- unresolved decisions and bounded assumptions
+
+Separate facts, decisions, assumptions, and open questions. Do not present a preferred design as an existing repository fact.
+
+### 4. Choose the plan shape
+
+Use the smallest structure that makes the work executable:
+
+- **Compact plan** for a bounded removal, migration, fix, or configuration change.
+- **Implementation plan** for a new component, refactor, API change, or multi-phase task whose direction is decided.
+- **Design draft** when alternatives, compatibility strategy, package boundaries, or architecture remain unresolved.
+
+Read [references/plan-templates.md](references/plan-templates.md) completely, then select and adapt one template. Do not emit empty or irrelevant sections.
+
+### 5. Write the plan
+
+Make each step actionable and verifiable. Name concrete packages, APIs, files, commands, or contracts when repository evidence supports them.
+
+Add conditional sections when material:
+
+- breaking changes and affected downstream users
+- before-and-after API or behavior comparisons
+- ordered migration steps
+- context, cancellation, errors, panic, ordering, concurrency, persistence, timeout, retry, or lifecycle semantics
+- rollout, rollback, data migration, or deployment requirements
+- independent pull request boundaries and dependency order
+- risks, rejected alternatives, and decision gates
+
+For incompatible changes, give every removed or changed public surface a replacement, migration action, or explicit statement that no direct replacement exists.
+
+Use the user's language for prose unless repository convention requires otherwise. Keep code identifiers, status tokens, commands, and filename slugs in their native form.
+
+### 6. Create and validate the artifact
+
+When the repository uses numbered status-bearing filenames:
+
+1. List every plan file, including hidden and ignored files.
+2. Read the numeric prefix only from filenames that follow the repository convention.
+3. Identify existing duplicate numbers instead of assuming the directory is clean.
+4. Use the highest existing number plus one unless repository instructions define another allocation rule. Do not reuse gaps merely because a lower number is available.
+5. Format the number, current date, status, and short topic according to repository convention.
+6. Confirm that the complete target path does not already exist before writing.
+
+After writing or renaming a plan, inspect the final file and check:
+
+- filename, metadata status, and metadata date agree
+- exactly one title, status field, and date field are present
+- the sequence number does not collide with another plan
+- checklist items describe observable work
+- validation commands exist and match the affected scope
+- completed checks have evidence
+- no absolute local paths, credentials, temporary files, or stale debug output remain
+- the plan contains no unauthorized runtime implementation changes
+
+If the plan directory is ignored by Git, report that fact and do not force-add it.
+
+### 7. Maintain lifecycle truthfully
+
+Use status according to execution state:
+
+- `draft`: important design choices are still open; do not present it as ready to execute.
+- `planned`: design and scope are sufficiently decided for implementation.
+- `in-progress`: authorized implementation has begun.
+- `blocked`: active execution cannot proceed until a concrete blocker changes.
+- `completed`: implementation and required validation are finished, not merely the plan document.
+
+When status changes, rename the file and update its metadata in the same edit. Preserve the original plan date unless repository convention says otherwise. Check off items only when evidence supports completion. Record the blocker and next unblocking action for `blocked` plans.
+
+Move reusable project facts into the repository's memory or context mechanism when one exists; keep one-off execution notes in the plan.
+
+## Quality Bar
+
+Before handing off a plan, verify that:
+
+- a future implementer can tell what to change and what not to change
+- completion can be determined without subjective interpretation
+- important behavior and compatibility decisions are explicit
+- tests and validation are proportional to risk
+- phases and pull requests are independently reviewable where practical
+- open questions are real decision gates, not a substitute for investigation
+- the plan reflects current repository evidence rather than an earlier idea
+
+For a conversational proposal, summarize the recommendation, evidence, scope, tradeoffs, and next implementation steps. For a durable artifact, report its path, status, scope, and whether it is ignored or tracked; state that runtime code was not changed unless the user separately authorized implementation.

--- a/skills/create-plan/agents/openai.yaml
+++ b/skills/create-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Plan"
+  short_description: "Create repository-aware technical plans"
+  default_prompt: "Use $create-plan to investigate this repository and create a scoped, actionable technical plan."

--- a/skills/create-plan/references/plan-conventions.md
+++ b/skills/create-plan/references/plan-conventions.md
@@ -1,0 +1,175 @@
+# Plan Conventions
+
+Use these conventions when creating or maintaining repository-local technical plans. Repository-specific instructions override this reference.
+
+## Contents
+
+1. Artifact selection
+2. Discovery and evidence
+3. Filename and metadata
+4. Status lifecycle
+5. Content and language
+6. Scope and execution boundaries
+7. Plan maintenance
+
+## 1. Artifact Selection
+
+Do not write a file merely because the user asked for an assessment or said "先给方案". Return a conversational proposal unless the user explicitly asks to create, save, record, or update a plan document.
+
+Use a durable plan when work is non-trivial and benefits from one or more of:
+
+- multiple implementation phases or pull requests
+- public API or behavior decisions
+- breaking changes and downstream migration
+- risky lifecycle, concurrency, persistence, data, or deployment behavior
+- several affected modules or adapters
+- explicit validation and completion tracking
+
+For a one-step change with an obvious implementation and validation path, prefer a compact plan or no durable artifact unless requested.
+
+## 2. Discovery and Evidence
+
+Read applicable repository instructions before inspecting plans. Plan directories may be ignored, so ordinary `rg --files` or `git ls-files` can omit the most relevant examples.
+
+Use discovery that includes ignored content:
+
+```bash
+rg --files --hidden --no-ignore <candidate-plan-directory>
+```
+
+Inspect at least one plan with a similar task shape. For repositories with mixed history, infer current conventions from the newest relevant files and explicit `AGENTS.md` rules rather than copying the oldest plan.
+
+Build the plan from:
+
+1. current source and tests
+2. current dependency and build metadata
+3. repository instructions
+4. current issues, pull requests, or upstream documentation when relevant
+5. prior plans and conversation as secondary context
+
+State uncertainty explicitly. Do not invent commands, paths, APIs, consumers, or migration requirements.
+
+## 3. Filename and Metadata
+
+When the repository uses ordered status-bearing names, prefer:
+
+```text
+NNN-YYYY-MM-DD-status-short-topic.md
+```
+
+Rules:
+
+- Use a three-digit sequence.
+- Scan ignored files before allocating the next sequence.
+- Use the current local date unless the user specifies another date.
+- Use one of `draft`, `planned`, `in-progress`, `blocked`, or `completed`.
+- Use a short lowercase kebab-case topic slug.
+- Reject duplicate sequence numbers even when the remaining filename differs.
+- Keep filename date and status synchronized with document metadata.
+
+Allocate the sequence as follows:
+
+1. List all plan filenames, including ignored and hidden files.
+2. Collect the three-digit prefixes from filenames that match the active convention.
+3. Note any existing duplicate prefixes so they are not repeated.
+4. Select the highest prefix plus one; do not fill an older gap unless repository instructions explicitly require it.
+5. Check that the complete target filename is unused before creating the file.
+
+If the next value no longer fits the repository's width convention, stop and ask how the repository wants to extend the scheme rather than silently changing it.
+
+Metadata may follow the plan language:
+
+```markdown
+状态：planned
+日期：2026-07-13
+```
+
+or:
+
+```markdown
+Status: planned
+Date: 2026-07-13
+```
+
+Do not mix languages within one metadata block. Manually confirm that the status and date each appear exactly once and match the filename.
+
+If the repository has a different naming scheme, follow it and do not force this format.
+
+## 4. Status Lifecycle
+
+### draft
+
+Use when the document compares alternatives or still contains decision gates that prevent direct implementation. Include evidence, options, tradeoffs, a current preference if one exists, and the decisions required to promote it to `planned`.
+
+### planned
+
+Use when the target design, scope, non-goals, implementation phases, and validation strategy are sufficiently decided. Open questions may remain only when they do not block the next phase.
+
+### in-progress
+
+Use only after implementation has started with authorization. Check off work based on repository evidence. Do not mark an item complete merely because code was drafted if its required tests or review are still pending.
+
+### blocked
+
+Use when active work cannot proceed. Record:
+
+- the concrete blocker
+- evidence already gathered
+- safe work that remains possible
+- the input or external change needed to continue
+
+### completed
+
+Use only when the objective and required validation are complete. Record actual validation, deviations from the original plan, and remaining follow-up work that is explicitly out of scope.
+
+Rename the file whenever the status changes. Keep the metadata synchronized in the same change.
+
+## 5. Content and Language
+
+Match the user's language for prose. Preserve API names, code, package paths, status tokens, and commands. Prefer concise Chinese plans for Chinese requests unless the repository requires English.
+
+Use repository-relative paths in durable plans. Avoid:
+
+- absolute workstation paths
+- temporary directories and cache paths
+- credentials, internal hosts, and machine-specific details
+- raw command output that will become stale
+- long transcripts of exploratory work
+
+Keep implementation history and version migration details in the location chosen by the repository. If the convention says migrations belong in pull request descriptions rather than README files, reflect that boundary in the plan.
+
+## 6. Scope and Execution Boundaries
+
+A plan should define:
+
+- the user or system outcome
+- affected components and public contracts
+- explicit non-goals
+- dependencies and sequencing
+- implementation phases
+- validation and completion criteria
+
+Do not broaden authority. Creating a plan does not authorize:
+
+- editing runtime code
+- creating a branch
+- committing or pushing
+- opening a pull request
+- changing external systems
+
+Perform read-only investigation freely within the named scope. Stop and request direction when a missing choice would materially change the outcome or public contract.
+
+## 7. Plan Maintenance
+
+Update the existing plan instead of creating a second plan for the same objective unless the work has genuinely split into independent efforts.
+
+When implementation reveals a changed decision:
+
+1. update the design and affected checklist items
+2. record the reason briefly
+3. remove stale instructions that should no longer be executed
+4. update validation and migration requirements
+
+Plans are execution aids, not append-only logs. Preserve important decisions, but keep the current path unambiguous.
+
+When a repository has a memory or durable-context directory, move reusable architectural facts there after completion. Leave task-specific commands, checklists, and PR sequencing in the plan.

--- a/skills/create-plan/references/plan-templates.md
+++ b/skills/create-plan/references/plan-templates.md
@@ -1,0 +1,275 @@
+# Adaptive Plan Templates
+
+Select the smallest template that makes the work executable. Remove irrelevant sections and add conditional sections only when supported by repository evidence.
+
+## Contents
+
+1. Compact plan
+2. Implementation plan
+3. Design draft
+4. Conditional sections
+5. Checklist writing rules
+
+## 1. Compact Plan
+
+Use for a bounded removal, migration, bug fix, dependency change, or configuration update.
+
+```markdown
+# <Outcome-oriented title>
+
+状态：planned
+日期：YYYY-MM-DD
+
+## 目标
+
+<One concrete outcome and its reason.>
+
+## 范围
+
+- <Included work>
+- <Explicitly excluded adjacent work>
+
+## 决策
+
+<The chosen approach and why it is appropriate.>
+
+## 迁移要点
+
+<!-- Include only for incompatible changes. -->
+- <Required downstream action>
+
+## 验证
+
+- [ ] `<repository command>`
+- [ ] <Focused behavioral check>
+```
+
+Omit `迁移要点` when the change is compatible.
+
+## 2. Implementation Plan
+
+Use for a new component, refactor, public API change, or work spanning several phases.
+
+````markdown
+# <Component or refactor title>
+
+状态：planned
+日期：YYYY-MM-DD
+
+## 背景与当前问题
+
+<Verified current behavior, evidence, and why change is needed.>
+
+## 目标
+
+- <Observable outcome>
+- <Completion criterion>
+
+## 范围
+
+- <Included component or contract>
+
+## 非目标
+
+- <Adjacent work deliberately excluded>
+
+## 设计结论
+
+| 能力或问题 | 结论 | 理由 |
+| --- | --- | --- |
+| ... | ... | ... |
+
+## 目标 API 或行为
+
+```text
+<Signatures, data flow, or state transition when useful>
+```
+
+## 运行语义
+
+<Errors, context, cancellation, panic, ordering, concurrency, lifecycle, persistence, or defaults.>
+
+## 实施阶段
+
+### 阶段 1：<Reviewable outcome>
+
+1. <Action>
+2. <Action>
+
+### 阶段 2：<Reviewable outcome>
+
+1. <Action>
+
+## 测试计划
+
+- [ ] <Normal behavior>
+- [ ] <Boundary or failure behavior>
+- [ ] <Concurrency, race, migration, or compatibility check when relevant>
+
+## 验证命令
+
+```bash
+<commands that exist in this repository>
+```
+
+## 执行清单
+
+- [ ] <Concrete implementation step>
+- [ ] <Documentation or metadata step>
+- [ ] <Validation step>
+````
+
+Add breaking change, migration, rollout, or pull request sections from the conditional set when needed.
+
+## 3. Design Draft
+
+Use when package boundaries, API shape, compatibility strategy, architecture, or another material decision remains open.
+
+```markdown
+# <Topic> 设计草案
+
+状态：draft
+日期：YYYY-MM-DD
+
+## 草案说明
+
+<State why this is not yet ready for implementation and what must be decided.>
+
+## 背景
+
+<Verified current state and constraints.>
+
+## 核心问题
+
+1. <Decision question>
+2. <Decision question>
+
+## 备选方案
+
+### 方案 A：<Name>
+
+<Shape, benefits, costs, compatibility, and risks.>
+
+### 方案 B：<Name>
+
+<Shape, benefits, costs, compatibility, and risks.>
+
+## 初步倾向
+
+<Preferred option and evidence, or state that no preference is justified yet.>
+
+## 决策门槛
+
+- [ ] <Evidence or decision required before promotion to planned>
+
+## 候选实施阶段
+
+<Only enough sequencing to evaluate feasibility; do not present unresolved work as approved execution.>
+
+## 待确认问题
+
+- <A question whose answer materially changes the design>
+```
+
+Promote the file to `planned` only after resolving the decision gates and rewriting the document into an unambiguous execution path.
+
+## 4. Conditional Sections
+
+### Breaking Changes
+
+Add when downstream users must change code, configuration, data, deployment, or operating assumptions.
+
+```markdown
+## 破坏性变更
+
+### 公开 API
+
+- 删除 `<OldAPI>`；使用 `<NewAPI>`。
+
+### 行为变化
+
+- <Changed default, error, context, panic, ordering, timeout, retry, persistence, or lifecycle behavior.>
+```
+
+### Before and After
+
+Use a table for several direct mappings and code for the primary migration path.
+
+```markdown
+## 迁移对照
+
+| 变更前 | 变更后 |
+| --- | --- |
+| `<old>` | `<new>` |
+```
+
+Make code examples self-contained enough to understand required imports and surrounding declarations.
+
+### Migration
+
+```markdown
+## 迁移步骤
+
+1. 更新 import 或模块路径。
+2. 替换被删除的 API。
+3. 调整改变的默认值或错误处理。
+4. 执行兼容性和回归验证。
+```
+
+State explicitly when no direct replacement exists. Separate required upgrade work from optional improvements.
+
+### Pull Request Boundaries
+
+```markdown
+## PR 拆分
+
+### PR 1：<Independent foundation>
+
+- <Scope>
+- <Validation>
+
+### PR 2：<Dependent migration>
+
+- 依赖 PR 1 合并。
+- <Scope>
+```
+
+Each pull request should be independently reviewable and avoid temporary public APIs unless the transition requires them.
+
+### Rollout and Rollback
+
+Add for data, infrastructure, deployment, protocol, or high-risk operational changes.
+
+Cover:
+
+- compatibility window
+- rollout order
+- observability and success signals
+- abort conditions
+- rollback mechanism
+- irreversible steps
+
+### Current Status
+
+Add to `in-progress`, `blocked`, or `completed` plans when a short status summary materially helps handoff. Report evidence, not a diary of every command.
+
+## 5. Checklist Writing Rules
+
+Write checklist items that can be objectively completed.
+
+Prefer:
+
+```markdown
+- [ ] Replace `WithRetryPolicy` call sites with `WithMaxAttempts` and `WithBackoff`.
+- [ ] Run `go test -race ./...` in the affected module.
+```
+
+Avoid:
+
+```markdown
+- [ ] Improve the implementation.
+- [ ] Make tests better.
+- [ ] Review everything.
+```
+
+Separate implementation, documentation, metadata, migration, and validation work when they can fail independently. Do not check an item until its stated result and required validation are complete.


### PR DESCRIPTION
## Summary

Add a guide-only `create-plan` skill for creating and maintaining evidence-backed technical plans without bundled executable dependencies.

## Changes

- Distinguish conversational proposals, durable plan artifacts, and lifecycle updates
- Require repository-aware discovery, including hidden and ignored plan files
- Provide adaptive templates for compact plans, implementation plans, and unresolved design drafts
- Document plan numbering, status transitions, scope boundaries, breaking changes, migration guidance, validation, and pull request sequencing
- Add skill metadata and Codex UI metadata

## Motivation

- Make technical plans consistent, actionable, and grounded in current repository evidence
- Support both lightweight proposals and durable execution plans without forcing one oversized template
- Keep plan creation portable by relying on agent guidance instead of custom scripts or runtime dependencies

## Testing

- `npx next build --webpack`
- Parsed the new `SKILL.md` frontmatter through the marketplace parser
- Forward-tested conversational, durable artifact, and script-free numbering scenarios with isolated agents
- `git diff --check`
- `npm run lint` is currently blocked while loading `react/display-name` by the installed ESLint and React plugin versions
- The standard Turbopack build path is blocked by sandbox port permissions; the repository-approved webpack fallback completed successfully