### PR TITLE
feat(release): add GitHub release writing skills

### DIFF
--- a/skills/github-release-notes-writer/SKILL.md
+++ b/skills/github-release-notes-writer/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: github-release-notes-writer
+description: Draft or update user-focused GitHub Release Notes from verified tags, commits, pull requests, existing releases, and supplied changelog baselines. Use when preparing prerelease or stable release notes, turning GitHub's generated What's Changed list into a curated narrative, documenting upgrades or breaking changes, or producing a major-version migration summary. Do not use merely to validate a repository changelog fragment.
+metadata:
+  name: GitHub Release Notes Writer
+  description: Write accurate, user-focused GitHub Release Notes with practical upgrade and migration guidance.
+  author: Flc
+  created: "2026-07-27T00:55:09Z"
+---
+
+# GitHub Release Notes Writer
+
+Write Release Notes that help users understand why a release matters and how to upgrade safely without losing the exact changelog record.
+
+## Operating Boundaries
+
+- Default to a local Markdown draft. Do not create, edit, publish, or delete a GitHub Release unless the user explicitly asks for that write.
+- Inspect release URLs, tags, pull requests, and repository content read-only when the user asks to research or draft.
+- Treat Release Notes as user- and upgrader-facing. Do not copy a reviewer-focused Release PR description unchanged.
+- Preserve the exact changelog baseline while curating its narrative and categories.
+- Prefer current code, tests, documentation, tags, and GitHub state over recalled conversation details.
+
+## Workflow
+
+### 1. Discover release conventions and inputs
+
+Read applicable repository instructions, release documentation, recent Release Notes, version manifests, and any user-provided baseline.
+
+Identify:
+
+- repository and target version
+- prerelease or stable status
+- immediate previous tag
+- target tag or immutable target commit
+- release branch when the target tag does not yet exist
+- last stable version of the previous major when preparing a stable major release
+- monorepo or multi-module upgrade requirements
+- requested output path and whether publication is authorized
+
+Follow the repository's established tone and heading style unless the user asks for another format.
+
+### 2. Resolve the exact changelog range
+
+Use the immediate previous tag to target tag or commit for `What's Changed` and the Full Changelog link:
+
+```bash
+git fetch --tags
+git rev-parse <previous-tag>^{commit}
+git rev-parse <target-tag-or-commit>^{commit}
+git log --format='%H%x09%s' <previous-tag>..<target>
+```
+
+When the target is a stable major release following prereleases, use two layers:
+
+| Layer | Purpose |
+| --- | --- |
+| Immediate previous tag to target | Exact PR inventory and Full Changelog |
+| Previous stable major to target | Concise cumulative upgrade and migration context, not automatically an exact Git range |
+
+Do not replace the exact delta inventory with the cumulative major-version story. Link earlier prerelease notes when they already contain detailed history.
+
+Before describing the previous stable major as a Git comparison range, verify ancestry:
+
+```bash
+git merge-base --is-ancestor <previous-stable-tag> <target>
+```
+
+If it is not an ancestor, treat the stable-to-major relationship as a conceptual migration scope assembled from published releases, migration documentation, branch history, and final APIs. Do not assign it an exact commit or PR inventory and do not present a three-dot comparison link as authoritative.
+
+If the target tag does not exist, label the range as provisional and do not claim a final Full Changelog URL is verified.
+
+### 3. Build and reconcile the exact inventory
+
+Treat the resolved commit range as the primary membership boundary. Extract PR references from commits and resolve ambiguous commits through GitHub commit-to-PR associations.
+
+If the user provides a generated `What's Changed` baseline:
+
+- preserve it as an inclusion source
+- compare its PR-number set with the Git range
+- resolve duplicates, missing PRs, direct commits, reverts, and release-preparation PRs
+- explain every deliberate addition or removal
+
+Include the release-preparation PR when its merged commit is inside the final range or the verified baseline includes it. Keep it in the inventory without presenting metadata alignment as a product highlight.
+
+Maintain an internal deduplicated list containing PR number, title, author, category, and user impact.
+
+### 4. Research user impact
+
+Inspect the important PRs, final code, tests, examples, and documentation. Determine:
+
+- new user-visible capabilities
+- important fixes and changed behavior
+- breaking APIs, defaults, configuration, data, or operational assumptions
+- required and optional upgrade actions
+- supported runtime or dependency changes
+- multi-module version alignment requirements
+
+Do not infer breaking behavior from titles alone. Verify final signatures and semantics. Include short before-and-after examples only when they materially improve migration safety.
+
+### 5. Draft the Release Notes
+
+Read [references/release-notes-conventions.md](references/release-notes-conventions.md) completely before drafting.
+
+Use an adaptive structure. Lead with the release outcome and upgrade command, then explain highlights and migrations before the complete categorized inventory.
+
+For multi-module ecosystems, tell users to upgrade every directly used module to a compatible release version when the repository evidence requires alignment.
+
+### 6. Validate the draft
+
+Before handoff or publication:
+
+- verify version names, tag SHAs, comparison range, PR count, and deduplicated PR-number set
+- compare the final inventory against the supplied baseline, if any
+- ensure every highlight and migration claim is supported by final repository evidence
+- ensure breaking changes identify affected users and required actions
+- verify code examples against the released API
+- verify the Full Changelog link uses the immediate previous tag and target tag
+- remove absolute local paths, credentials, private hosts, temporary filenames, and machine-specific output
+- keep ordinary Markdown paragraphs naturally wrapped; never enforce a source-code line-width limit
+
+### 7. Write locally by default
+
+Use the user's requested destination. Otherwise create a clearly named temporary Markdown draft outside the repository unless repository instructions specify a release-draft location.
+
+Report the path and leave GitHub unchanged.
+
+### 8. Publish only with explicit authorization
+
+When the user explicitly asks to create or update the GitHub Release, use the reviewed local draft:
+
+```bash
+gh release edit <tag> --notes-file <draft-file>
+gh release view <tag> --json tagName,name,isDraft,isPrerelease,body
+```
+
+Use `gh release create` only when the user explicitly asks to create a new Release and the target tag, title, draft/prerelease state, and target commit are verified.
+
+After any write, read the Release back and verify its body and state. Do not alter assets, tags, titles, draft state, prerelease state, or latest-release status unless requested.
+
+## Handoff
+
+Report:
+
+- target release and exact changelog range
+- cumulative migration range or conceptual scope when used
+- exact included PR count
+- supplied-baseline reconciliation result
+- local draft path
+- whether GitHub was changed
+- provisional links, missing evidence, or intentionally omitted content

--- a/skills/github-release-notes-writer/SKILL.md
+++ b/skills/github-release-notes-writer/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   name: GitHub Release Notes Writer
   description: Write accurate, user-focused GitHub Release Notes with practical upgrade and migration guidance.
   author: Flc
-  created: "2026-07-27T00:55:09Z"
+  created: "2026-07-27T01:03:37Z"
 ---
 
 # GitHub Release Notes Writer

--- a/skills/github-release-notes-writer/agents/openai.yaml
+++ b/skills/github-release-notes-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Release Notes Writer"
+  short_description: "Write user-focused GitHub release notes and migrations"
+  default_prompt: "Use $github-release-notes-writer to inspect a GitHub release range and draft accurate user-focused Release Notes."

--- a/skills/github-release-notes-writer/references/release-notes-conventions.md
+++ b/skills/github-release-notes-writer/references/release-notes-conventions.md
@@ -1,0 +1,141 @@
+# GitHub Release Notes Conventions
+
+Use these conventions after the target version, exact comparison range, pull request inventory, and important user impacts have been verified.
+
+## Audience
+
+Write for users deciding whether and how to upgrade.
+
+The Release Notes must answer:
+
+1. What is this release?
+2. Why should users care?
+3. How do users upgrade?
+4. What must users change to remain compatible?
+5. What exactly changed since the immediate previous release?
+
+Do not narrate the release-preparation diff as though it were the release's main value.
+
+## Adaptive Structure
+
+Use the smallest set of sections that explains the release completely:
+
+```markdown
+# <version>
+
+<!-- One short paragraph positioning the release. -->
+
+## Upgrade
+
+<!-- Exact package, module, image, command, or installation guidance. -->
+
+## Highlights
+
+<!-- A curated summary of the most important user-visible outcomes. -->
+
+## Changes Since <previous-version>
+
+<!-- Important features, fixes, and behavioral changes in the exact delta. -->
+
+## Breaking Changes
+
+<!-- Affected users, before/after APIs or behavior, and required actions. -->
+
+## Migration Guide
+
+1. ...
+2. ...
+
+## What's Changed
+
+### New Features
+- ...
+
+### Fixes and Behavioral Changes
+- ...
+
+### Documentation
+- ...
+
+### Dependencies and Maintenance
+- ...
+
+**Full Changelog**: <comparison-link>
+```
+
+For a stable major release after prereleases, add a concise major-version migration section. Keep `What's Changed` scoped to the immediate previous tag. Link earlier prerelease notes instead of duplicating their full inventories. If the previous stable major is not an ancestor of the target tag, label this section as migration context rather than an exact Git range.
+
+Omit empty headings. Preserve a repository-provided title or introductory convention when one exists.
+
+## Upgrade Guidance
+
+- Give a direct upgrade command or dependency declaration when repository evidence supports one.
+- For a multi-module repository, state whether users must align all directly used modules to the release version.
+- Name minimum language, runtime, platform, database, or dependency requirements when they changed.
+- Separate required migration work from optional cleanup or newly recommended practices.
+- Do not promise compatibility that has not been verified.
+
+## Highlights
+
+- Select outcomes that affect user capability, correctness, safety, performance, operability, or upgrade decisions.
+- Combine related PRs into one coherent outcome.
+- Do not promote dependency churn, generated metadata, or the release PR itself as a headline unless it has material user impact.
+- Keep the number of highlights proportional to the release. A long release can still have a short highlight section.
+
+## Breaking Changes and Migration
+
+For each incompatible change:
+
+- name the affected API, module, configuration, wire format, data, or behavior
+- identify which users are affected
+- show the replacement or state that none exists
+- give ordered migration actions
+- call out changed semantics such as context, cancellation, panic, ordering, timeout, retry, lifecycle, persistence, or concurrency
+- state important preserved behavior when it prevents over-migration
+
+Use a compact mapping table when several old APIs have direct replacements:
+
+```markdown
+| Before | After |
+| --- | --- |
+| `oldpkg.Run(...)` | `newpkg.Run(...)` |
+```
+
+Use self-contained code examples only for the primary migration path. Verify imports, signatures, and behavior against the target release.
+
+## Exact Inventory Rules
+
+- Preserve every verified PR in the immediate comparison range.
+- Keep each PR in one primary category unless the repository convention requires another layout.
+- Include author attribution when the repository's generated format uses it.
+- Include release-preparation PRs when they are inside the range, but categorize them as release or maintenance work.
+- Summarize dependency updates compactly without dropping them from the complete inventory.
+- Identify direct commits without PRs.
+- Explain reverts so users can tell whether a previously announced capability remains.
+- Do not move older prerelease changes into the exact delta merely to make the stable release look more complete.
+
+## Writing Rules
+
+- Lead with user outcomes and required actions.
+- Use factual, calm language instead of promotional claims.
+- Prefer short paragraphs and scannable bullets.
+- Do not force Markdown source lines to a fixed width.
+- Do not copy raw commit logs when a user-centered category is clearer.
+- Do not publish local paths, temporary filenames, private infrastructure, credentials, or shell output.
+- Keep PR titles accurate when quoted; clarify user impact separately rather than rewriting history.
+- Link directly to PRs, prior releases, migration documentation, and the exact comparison when useful.
+
+## Completeness Check
+
+Before handoff, verify:
+
+- target and previous tags resolve to the stated commits
+- any cumulative stable-to-major Git range has a verified ancestor relationship; otherwise it is labeled as conceptual migration context
+- final PR count equals the deduplicated inventory
+- supplied baseline and final inventory reconcile exactly or have explained differences
+- every highlight is represented by released code or documentation
+- every breaking change has a concrete migration action
+- upgrade commands use the target version and correct module or package paths
+- prerelease-to-stable notes separate exact delta from cumulative migration context
+- the Full Changelog link compares the immediate previous tag with the target tag
+- the draft contains no forced line wrapping or machine-specific content

--- a/skills/github-release-pr-writer/SKILL.md
+++ b/skills/github-release-pr-writer/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: github-release-pr-writer
+description: Draft or update GitHub release pull request descriptions from verified tags, commits, merged pull requests, and the release diff. Use when a PR prepares a version, aligns release metadata, promotes a prerelease, or needs a reviewer-focused release summary, exact change inventory, breaking-change section, or migration summary. Do not use for ordinary feature or bug-fix pull requests.
+metadata:
+  name: GitHub Release PR Writer
+  description: Draft accurate, reviewer-focused descriptions for GitHub release pull requests.
+  author: Flc
+  created: "2026-07-27T00:55:09Z"
+---
+
+# GitHub Release PR Writer
+
+Write release pull request descriptions that help maintainers verify what will be released and why the release-preparation diff is correct.
+
+## Operating Boundaries
+
+- Treat this skill as a specialized companion to a general PR workflow. Use the general PR skill for branch readiness, ordinary change descriptions, reviewers, and PR creation.
+- Default to a local Markdown draft. Do not create or update a GitHub pull request unless the user explicitly asks for that write.
+- Inspect URLs and GitHub state read-only when the user asks to review, assess, draft, or improve wording.
+- Separate release-preparation changes from the product history being released.
+- Use repository evidence instead of reconstructing a release solely from conversation memory, commit wording, or the files changed by the release PR.
+
+## Workflow
+
+### 1. Discover repository and release conventions
+
+Read applicable repository instructions, PR templates, release documentation, version manifests, and representative recent release pull requests.
+
+Identify:
+
+- repository and target PR
+- base and head branches and immutable SHAs
+- intended version and release channel
+- previous released version or comparison tag
+- whether the repository uses squash, merge, or rebase commits
+- whether it is a monorepo or multi-module repository
+
+Do not assume the repository default branch is the release base.
+
+### 2. Inspect the target pull request
+
+Read the PR metadata and full base-to-head diff:
+
+```bash
+gh pr view <pr> --json number,title,body,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,commits,files,statusCheckRollup
+git diff <base-sha>...<head-sha>
+```
+
+Determine what the release PR itself changes, such as:
+
+- version manifests and exported version helpers
+- module or package dependency alignment
+- generated files, lockfiles, or release metadata
+- final compatibility fixes made only on the release branch
+
+Describe these as release-preparation changes, not as the entire release history.
+Use `statusCheckRollup` only to report checks that actually completed; distinguish successful, skipped, pending, cancelled, and failed checks.
+
+### 3. Resolve exact comparison ranges
+
+Use two distinct ranges:
+
+| Purpose | Default range |
+| --- | --- |
+| Release PR diff | PR base SHA to PR head SHA |
+| Changes being released | Previous release tag to PR base SHA |
+
+The second range normally excludes the release PR itself because that PR has not landed in its own base. If the repository uses another release model, explain and verify the adjusted boundary.
+
+Prefer immutable SHAs after resolving branch and tag names:
+
+```bash
+git fetch --tags
+git rev-parse <previous-tag>^{commit}
+git rev-parse <pr-base-sha>^{commit}
+git log --format='%H%x09%s' <previous-tag>..<pr-base-sha>
+```
+
+If the previous tag is ambiguous, inspect the tag graph and recent published releases. Do not silently choose the closest semantic version when multiple release lines are active.
+
+### 4. Build and reconcile the pull request inventory
+
+Treat the commit range as the membership boundary. Extract referenced PR numbers from commit subjects, then resolve ambiguous commits through GitHub commit-to-PR associations.
+
+For every candidate PR:
+
+- confirm its merged commit or released commits belong to the comparison range
+- record its number, title, author, and user impact
+- exclude the target release PR from the historical inventory unless it is truly inside the chosen released range
+- identify reverts, duplicate references, backports, and commits with no PR
+
+Maintain an internal exact set of PR numbers. If a user supplies a GitHub-generated `What's Changed` list, reconcile it against the range rather than replacing it casually. Explain every addition or removal.
+
+Do not use merged-date search alone as proof of range membership.
+
+### 5. Analyze release impact
+
+Group changes by user or maintainer impact rather than by filename:
+
+- breaking API or behavior changes
+- new components and capabilities
+- important fixes and behavioral corrections
+- documentation and repository structure
+- dependency, CI, and maintenance changes
+
+For breaking changes, verify the final code and tests, then provide:
+
+- affected public surface
+- before-and-after mapping when useful
+- required migration action
+- important preserved contracts
+
+For multi-module repositories, verify that version manifests, module requirements, exported version values, and release scope agree.
+
+### 6. Draft the description
+
+Read [references/release-pr-conventions.md](references/release-pr-conventions.md) completely before drafting.
+
+Adapt the structure to the evidence. Omit empty headings. Keep the result reviewer-focused: explain the release-preparation diff, summarize the shipped history, and make validation boundaries auditable.
+
+### 7. Sanitize and validate
+
+Before handing off or publishing:
+
+- verify the version names, comparison SHAs, PR count, and PR-number set
+- ensure every highlighted claim maps to code, documentation, tests, or an included PR
+- ensure breaking changes include migration guidance
+- ensure testing lists only checks that actually completed
+- remove absolute local paths, usernames, temporary files, tokens, hosts, and machine-specific output
+- keep Markdown paragraphs naturally wrapped; do not impose source-code line-width wrapping
+
+### 8. Publish only with explicit authorization
+
+When the user explicitly asks to update the PR, write the reviewed body to a temporary or user-selected Markdown file and use:
+
+```bash
+gh pr edit <pr> --body-file <draft-file>
+gh pr view <pr> --json body
+```
+
+Verify the final GitHub body after the write. Do not alter the title, reviewers, labels, state, or other PR fields unless requested.
+
+## Handoff
+
+Report:
+
+- target PR and intended release
+- released-history range and release-PR diff range
+- exact included PR count
+- local draft path, if created
+- whether GitHub was changed
+- unresolved evidence gaps or intentionally omitted items

--- a/skills/github-release-pr-writer/SKILL.md
+++ b/skills/github-release-pr-writer/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   name: GitHub Release PR Writer
   description: Draft accurate, reviewer-focused descriptions for GitHub release pull requests.
   author: Flc
-  created: "2026-07-27T00:55:09Z"
+  created: "2026-07-27T01:03:37Z"
 ---
 
 # GitHub Release PR Writer

--- a/skills/github-release-pr-writer/agents/openai.yaml
+++ b/skills/github-release-pr-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Release PR Writer"
+  short_description: "Draft evidence-backed GitHub release PR descriptions"
+  default_prompt: "Use $github-release-pr-writer to inspect a GitHub release pull request and draft an accurate reviewer-focused description."

--- a/skills/github-release-pr-writer/references/release-pr-conventions.md
+++ b/skills/github-release-pr-writer/references/release-pr-conventions.md
@@ -1,0 +1,105 @@
+# Release Pull Request Conventions
+
+Use these conventions after the release range, release-preparation diff, and exact pull request inventory have been verified.
+
+## Audience
+
+Write for maintainers reviewing whether the proposed release is complete and internally consistent.
+
+The description must answer:
+
+1. What does this release PR itself change?
+2. What product changes will the resulting release contain?
+3. Which compatibility or migration concerns require review?
+4. What evidence verifies the release?
+
+Do not turn the body into end-user release notes. Detailed upgrade tutorials, promotional language, and cumulative version history belong in the published Release Note unless they are necessary to review a breaking change.
+
+## Adaptive Structure
+
+Start from this structure and keep only sections supported by evidence:
+
+```markdown
+## Summary
+<!-- Intended version, release channel, and the purpose of this release PR. -->
+
+## Release Changes
+<!-- Version metadata, module alignment, generated artifacts, or final release-branch fixes changed by this PR. -->
+
+## Highlights
+<!-- A compact summary of the most important changes being released. -->
+
+## Pull Requests Since <previous-version>
+<!-- Exact categorized inventory for <previous-tag>..<pr-base-sha>. -->
+
+### Breaking API Changes
+- ...
+
+### New Components and Features
+- ...
+
+### Fixes and Behavioral Changes
+- ...
+
+### Documentation and Repository Structure
+- ...
+
+### Dependencies, CI, and Maintenance
+- ...
+
+## Migration Summary
+<!-- Required downstream actions only. Link detailed release or migration documentation when available. -->
+
+## Validation
+- ...
+
+## Notes
+<!-- Important scope boundaries, known gaps, or follow-up release work. -->
+```
+
+`Release Changes` and `Pull Requests Since ...` serve different purposes. Never collapse them in a way that implies version-file changes are the release's only content.
+
+## Inventory Rules
+
+- Preserve exact PR numbers and link each PR when the repository convention supports links.
+- Prefer one category per PR. If a PR genuinely spans categories, list it once in the category matching its primary user impact.
+- Keep dependency updates compact, but do not omit them from the exact inventory.
+- Identify direct commits without PRs separately when they are inside the range.
+- Treat reverts as changes in their own right and explain whether the reverted capability remains in the release.
+- Do not count the release PR itself in a previous-tag-to-PR-base range.
+- Do not list older prerelease work as newly introduced unless the chosen comparison range includes it.
+
+## Breaking Changes
+
+For each breaking change, include enough information to verify:
+
+- the removed or changed public API, module, configuration, or behavior
+- affected consumers
+- replacement or explicit absence of a replacement
+- ordered migration action
+- behavior that remains unchanged when the scope could be misunderstood
+
+A large refactor is not automatically breaking. A small default or semantic change can be breaking.
+
+## Writing Rules
+
+- Lead with the release outcome, not a file-by-file narration.
+- Use stable version names and repository-relative identifiers.
+- Keep claims factual and traceable.
+- Avoid empty sections, duplicated bullets, and raw commit dumps.
+- Do not force Markdown source lines to a fixed width.
+- Do not publish local paths, temporary filenames, credentials, private hosts, or shell history.
+- State only validation that actually ran and distinguish blocked checks from successful checks.
+
+## Completeness Check
+
+Before handoff, verify:
+
+- intended version matches every release metadata surface
+- previous tag and PR base resolve to the stated SHAs
+- PR count equals the deduplicated inventory
+- every inventory PR is inside the chosen range
+- the target release PR is excluded or included for an explicitly verified reason
+- every breaking change has a migration action
+- no highlighted change exists only in an abandoned plan or stale PR description
+- comparison and release links point to the intended repository and versions


### PR DESCRIPTION
## Summary

Add two specialized skills for producing accurate GitHub release artifacts: reviewer-focused Release PR descriptions and user-focused Release Notes.

## Changes

- Add `github-release-pr-writer` with separate release-preparation and released-history ranges, exact PR inventory reconciliation, migration guidance, and explicit GitHub write boundaries
- Add `github-release-notes-writer` with generated changelog reconciliation, prerelease-to-stable migration context, multi-module upgrade guidance, and natural Markdown wrapping
- Add focused writing conventions and OpenAI agent metadata for both skills
- Derive skill creation metadata from the first Git commit

## Motivation

- Make release writing repeatable and evidence-based while keeping Release PR descriptions distinct from published Release Notes

## Testing

- Validated both skills with `quick_validate.py`
- Generated Marketplace data for 27 skills
- Ran `npm run build`
- Replayed the workflows read-only against go-fries Release PR #2691 and the v4.0.0 release baseline
- `npm run lint` is currently blocked while loading the existing `react/display-name` rule because of the repository's ESLint 10 and `eslint-plugin-react` compatibility issue
