### PR TITLE
feat(web): redesign marketplace with soft modern visual system

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -1,72 +1,76 @@
-# Design System: Technical Atlas
+# Design System: Soft Modern
 
 ## 1. Visual Direction
 
-The marketplace is a technical atlas for reusable agent workflows. It should feel precise, spatial, and quietly cinematic: a map of operational knowledge rather than a conventional documentation site or marketing grid.
+The marketplace is a friendly, modern product surface for discovering reusable agent skills. It should feel light, calm, and effortless: soft cards floating on a quiet canvas, one confident accent color, and generous whitespace.
 
-- Default character: deep navy field, fine coordinate grid, signal nodes, and open record rows.
-- Creativity: 7/10. Distinctive enough to be recognizable, restrained enough for repeated technical use.
-- Density: 5/10. The first viewport stays focused; the catalog becomes denser as users browse.
-- Avoid the previous workshop ledger language entirely: no beige paper, verdigris, register surfaces, oversized black-on-cream typography, or archival stationery motifs.
+- Default character: warm off-white canvas, white rounded cards, diffused shadows, and a single indigo accent.
+- Creativity: 5/10. Familiar product patterns executed with restraint and polish.
+- Density: 4/10. The hero stays airy; the catalog is a comfortable card grid.
+- The previous "technical atlas" language is retired: no coordinate grids, signal nodes, diamond markers, hard rules, or navy station surfaces.
 
 ## 2. Color System
 
-### Dark signal
+### Light theme
 
-- Atlas Ink: `#07101E` — page canvas.
-- Station Surface: `#0D1B2E` — install panel, modal, and elevated controls.
-- Deep Station: `#102238` — secondary surfaces.
-- Primary Text: `#EEF6FF`.
-- Muted Text: `#8FA4BA`.
-- Coral Signal: `#FF715B` — primary accent, active nodes, important actions.
-- Cyan Signal: `#70D7E5` — focus, navigation, and information signal.
+- Background: `#FAF9F7` — warm off-white canvas.
+- Surface: `#FFFFFF` — cards, modal, popovers.
+- Surface Muted: `#F1F0EE` — inset fills (command rows, chips, segmented control track).
+- Foreground: `#1B1E28`.
+- Muted: `#68707F`.
+- Border: `rgba(27, 30, 40, 0.08)` / strong `0.14`.
+- Accent: `#6366F1` (indigo), Accent Strong: `#4F46E5`, Accent Soft: 10% indigo wash.
 
-### Light signal
+### Dark theme
 
-The light theme is the same atlas system under daylight, not a separate aesthetic.
+The dark theme is the same system at night, not a separate aesthetic.
 
-- Canvas: `#E7EEF5`.
-- Station Surface: `#F6F9FC`.
-- Secondary Surface: `#DCE7EF`.
-- Primary Text: `#0B1825`.
-- Muted Text: `#526A7E`.
-- Coral Signal: `#E95545`.
-- Cyan Signal: `#147F91`.
+- Background: `#0E0F13`.
+- Surface: `#17181E`.
+- Surface Muted: `#1F2129`.
+- Foreground: `#F2F3F7`.
+- Muted: `#9AA2B1`.
+- Border: `rgba(242, 243, 247, 0.09)` / strong `0.16`.
+- Accent: `#818CF8`, Accent Strong: `#A5B4FC`, Accent Soft: 14% wash.
 
-Never introduce purple AI gradients, beige paper surfaces, neon outer glows, or pure black.
+The only decorative treatment is a faint indigo radial glow at the top center of the page (`--glow`). No other gradients, no neon, no glassmorphism stacks.
 
 ## 3. Typography
 
-- Display: `Avenir Next`, Avenir, `Century Gothic`, or a humanist sans fallback. Use for the hero, section titles, modal titles, and record names.
-- Interface: Inter or the system sans stack. Use for descriptions, controls, and navigation.
-- Mono: SFMono-Regular, Menlo, or Consolas. Use for install commands, identifiers, counts, dates, and compact status text.
-- Headlines are geometric and humanist, with strong weight and open counters; they must fit cleanly on a 1280px desktop and 390px mobile viewport.
+- Display: `Plus Jakarta Sans` (loaded via `next/font/google` as `--font-jakarta`). Used for the hero, section titles, modal titles, card titles, and the wordmark. Apply via the `.font-display` class.
+- Interface: `Inter` (`--font-inter`). Body text, controls, navigation.
+- Mono: SFMono-Regular/Menlo stack. Install commands, dates, file counts, keyboard hints.
+- Headings use tight tracking and bold/extrabold weights; body text is regular/medium with relaxed leading.
 
 ## 4. Layout
 
-- Maximum content width: `1360px`.
-- Header: simple brand mark, theme selector, and GitHub link.
-- First viewport: asymmetric two-column composition. Search and collection facts sit with the main statement; the install station is the dominant secondary object.
-- Catalog: a full-width surface band containing open horizontal records separated by signal rules. Fade the band in over 48px at the top, then keep the surface opaque through the bottom of the page so record dividers stay easy to scan without reintroducing the page grid. Do not turn it into a generic card grid.
-- Detail: a large focused modal that preserves browsing context and uses the same station geometry.
-- Mobile: stack the hero and install station; catalog rows reduce metadata without losing the primary action.
+- Maximum content width: `72rem` (`max-w-6xl`).
+- Header: fixed, 64px, blurred translucent background, hairline bottom border. Left: rounded gradient brand mark + wordmark. Right: theme selector and GitHub link as circular icon buttons.
+- Hero: centered composition — headline, subtext, the search field as the hero object (large pill with ⌘K badge), then fact pills (skill count, file count).
+- Quick install: one centered `max-w-2xl` card below the hero containing the provider segmented control and command rows.
+- Catalog: a responsive card grid — 1 column on mobile, 2 on `sm`, 3 on `lg` — with a small heading row above it.
+- Detail: a centered `rounded-3xl` modal that preserves browsing context.
+- Footer: centered wordmark, one-line description, copyright.
+- Mobile: everything stacks; cards go full width; the search pill keeps its primary action.
 
 ## 5. Component Language
 
-- Brand mark: a white geometric SVG `FS` monogram on a coral cut-corner tile, offset over an Atlas Ink tile to create a compact two-layer signal mark. Keep the ink layer structural rather than shadow-like.
-- Signal nodes: small diamonds or points, used sparingly for catalog position and spatial rhythm.
-- Install station: one elevated panel with a coral top rule and exact copy controls.
-- Search: one long command-like field with a cyan icon zone and keyboard shortcut.
-- Catalog rows: open, border-separated, and hover toward a faint coral signal wash.
-- Buttons: square or lightly rectangular, minimum 44px target, thin structural border, no pill treatment unless required by an external component.
-- Empty/error states: inline atlas messages near the affected content.
+- Brand mark: white `FS` monogram on a rounded-square (`rx=11`) indigo gradient tile.
+- Cards: `rounded-2xl`, 1px `--border`, `--shadow-card`. Hover: `-translate-y-1`, accent-tinted border, `--shadow-card-hover`.
+- Buttons and inputs: `rounded-full` for pills/icon buttons, `rounded-xl` for inset rows. Minimum 44px touch target where practical.
+- Chips/badges: `rounded-full` fills of `--surface-muted`; accent actions use `--accent-soft` background with `--accent` text.
+- Search: one large pill field, search icon on the left, `⌘K` kbd chip on the right, accent focus ring via border + shadow.
+- Segmented control: muted track pill with a white/surface sliding indicator (`layoutId` spring).
+- Copy buttons: circular, surface background; success state fills with `--accent`.
+- Empty/error states: centered, dashed-border panel or soft accent wash, inline near the affected content.
 
 ## 6. Motion
 
-- Use 160–220ms state transitions and restrained spring entrances.
-- Animate opacity and transform for catalog filtering and modal transitions.
-- Hover states may illuminate a signal node or move an arrow by a few pixels.
-- Respect `prefers-reduced-motion` everywhere.
+- Springs over easings: cards enter with a soft spring (`stiffness ~260, damping ~28`) and a short per-item stagger (≤12 items, ~35ms each).
+- Catalog filtering uses `AnimatePresence mode="popLayout"` with `layout` springs; the stagger delay applies to entrance only, never to layout reflow.
+- Modal: backdrop fade (200ms), panel spring from `scale 0.96 / y 16`.
+- Hover: lift cards, slide arrows a pixel, tint icon buttons. 150–250ms.
+- Respect `prefers-reduced-motion` everywhere (`MotionConfig reducedMotion="user"` plus the global CSS guard).
 
 ## 7. Functional Invariants
 
@@ -84,11 +88,10 @@ Never introduce purple AI gradients, beige paper surfaces, neon outer glows, or 
 
 ## 8. Anti-patterns
 
-- No reuse of the previous ledger/workshop visual language.
-- No beige, paper clay, verdigris, or stationery metaphors.
-- No default bento grid or repeated floating cards.
+- No revival of the atlas/ledger visual languages (grids, signal nodes, navy stations, beige paper).
+- No heavy gradients, glassmorphism stacks, or glow effects beyond the single page glow.
+- No sharp-cornered cards or hard uppercase microcopy.
 - No fake metrics or fabricated proof.
-- No decorative badge clutter or hero eyebrow labels.
-- No generic AI gradients or glow-heavy cyberpunk treatment.
+- No decorative badge clutter.
 - No text glyphs when an existing icon component communicates the action.
 - No clipped commands, headings, or mobile controls.

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -67,9 +67,15 @@ The only decorative treatment is a faint tangerine radial glow at the top center
 ## 6. Motion
 
 - Springs over easings: cards enter with a soft spring (`stiffness ~260, damping ~28`) and a short per-item stagger (≤12 items, ~35ms each).
+- The hero (headline, subtext, search, fact pills, install panel) enters as a choreographed sequence — fade-up with ~70ms stagger.
+- Stat numbers (skill/file counts) count up from 0 on first paint (~700ms, instant under reduced motion).
 - Catalog filtering uses `AnimatePresence mode="popLayout"` with `layout` springs; the stagger delay applies to entrance only, never to layout reflow.
+- Press feedback uses Motion `whileTap` scale springs on cards, tabs, and copy buttons (no CSS `:active` transforms — inline Motion transforms would override them anyway).
+- Copy success swaps the icon with a spring pop (`scale 0.4 → 1`, slight overshoot) via `AnimatePresence mode="wait"`.
+- The install provider tabs slide their indicator (`layoutId`) and cross-slide the command area on switch.
+- Card hover lift is `whileHover={{ y: -4 }}` (Motion-driven, not a CSS transform, so it composes with layout animations).
+- Theme switching transitions colors globally (200ms on background/border/color/fill/stroke/box-shadow via a `@layer base` rule that utilities can override).
 - Modal: backdrop fade (200ms), panel spring from `scale 0.96 / y 16`.
-- Hover: lift cards, slide arrows a pixel, tint icon buttons. 150–250ms.
 - Respect `prefers-reduced-motion` everywhere (`MotionConfig reducedMotion="user"` plus the global CSS guard).
 
 ## 7. Functional Invariants

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -73,7 +73,9 @@ The only decorative treatment is a faint tangerine radial glow at the top center
 - Press feedback uses Motion `whileTap` scale springs on cards, tabs, and copy buttons (no CSS `:active` transforms — inline Motion transforms would override them anyway).
 - Copy success crossfades the icon/label in place — both states share one grid cell and animate opacity + scale simultaneously (150ms, `cubic-bezier(0.34, 1.56, 0.64, 1)` for a slight overshoot). Never serialize exit-then-enter here (no `AnimatePresence mode="wait"`); it leaves a dead gap with nothing visible.
 - The install provider tabs slide their indicator (`layoutId`) and cross-slide the command area on switch.
-- Card hover lift is `whileHover={{ y: -4 }}` (Motion-driven, not a CSS transform, so it composes with layout animations).
+- Card hover lift is `whileHover={{ y: -4 }}` (Motion-driven, not a CSS transform, so it composes with layout animations). On hover the title also shifts to the accent color and the arrow button fills.
+- Hovered cards show a cursor-following spotlight: a ~220px radial wash of the accent at 7% alpha, driven by Motion values (no React re-renders on mousemove), faded in/out over 300ms. Keep it at or under 8% alpha — it should read as a sheen, not a glow.
+- Empty states animate in: the panel fades up while the icon springs in with a low-damping wobble.
 - Theme switching transitions colors globally (200ms on background/border/color/fill/stroke/box-shadow via a `@layer base` rule that utilities can override).
 - Modal: backdrop fade (200ms), panel spring from `scale 0.96 / y 16`.
 - Respect `prefers-reduced-motion` everywhere (`MotionConfig reducedMotion="user"` plus the global CSS guard).

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -4,7 +4,7 @@
 
 The marketplace is a friendly, modern product surface for discovering reusable agent skills. It should feel light, calm, and effortless: soft cards floating on a quiet canvas, one confident accent color, and generous whitespace.
 
-- Default character: warm off-white canvas, white rounded cards, diffused shadows, and a single indigo accent.
+- Default character: warm off-white canvas, white rounded cards, diffused shadows, and a single vivid tangerine accent.
 - Creativity: 5/10. Familiar product patterns executed with restraint and polish.
 - Density: 4/10. The hero stays airy; the catalog is a comfortable card grid.
 - The previous "technical atlas" language is retired: no coordinate grids, signal nodes, diamond markers, hard rules, or navy station surfaces.
@@ -19,7 +19,7 @@ The marketplace is a friendly, modern product surface for discovering reusable a
 - Foreground: `#1B1E28`.
 - Muted: `#68707F`.
 - Border: `rgba(27, 30, 40, 0.08)` / strong `0.14`.
-- Accent: `#6366F1` (indigo), Accent Strong: `#4F46E5`, Accent Soft: 10% indigo wash.
+- Accent: `#FF5C33` (vivid tangerine), Accent Strong: `#E84620`, Accent Soft: 10% tangerine wash.
 
 ### Dark theme
 
@@ -31,9 +31,9 @@ The dark theme is the same system at night, not a separate aesthetic.
 - Foreground: `#F2F3F7`.
 - Muted: `#9AA2B1`.
 - Border: `rgba(242, 243, 247, 0.09)` / strong `0.16`.
-- Accent: `#818CF8`, Accent Strong: `#A5B4FC`, Accent Soft: 14% wash.
+- Accent: `#FF8A66`, Accent Strong: `#FFA585`, Accent Soft: 16% wash.
 
-The only decorative treatment is a faint indigo radial glow at the top center of the page (`--glow`). No other gradients, no neon, no glassmorphism stacks.
+The only decorative treatment is a faint tangerine radial glow at the top center of the page (`--glow`). No other gradients, no neon, no glassmorphism stacks. Never use blue-violet/indigo as the accent — it reads as generic AI-product branding.
 
 ## 3. Typography
 
@@ -55,7 +55,7 @@ The only decorative treatment is a faint indigo radial glow at the top center of
 
 ## 5. Component Language
 
-- Brand mark: white `FS` monogram on a rounded-square (`rx=11`) indigo gradient tile.
+- Brand mark: white `FS` monogram on a rounded-square (`rx=11`) tangerine gradient tile.
 - Cards: `rounded-2xl`, 1px `--border`, `--shadow-card`. Hover: `-translate-y-1`, accent-tinted border, `--shadow-card-hover`.
 - Buttons and inputs: `rounded-full` for pills/icon buttons, `rounded-xl` for inset rows. Minimum 44px touch target where practical.
 - Chips/badges: `rounded-full` fills of `--surface-muted`; accent actions use `--accent-soft` background with `--accent` text.

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -71,7 +71,7 @@ The only decorative treatment is a faint tangerine radial glow at the top center
 - Stat numbers (skill/file counts) count up from 0 on first paint (~700ms, instant under reduced motion).
 - Catalog filtering uses `AnimatePresence mode="popLayout"` with `layout` springs; the stagger delay applies to entrance only, never to layout reflow.
 - Press feedback uses Motion `whileTap` scale springs on cards, tabs, and copy buttons (no CSS `:active` transforms — inline Motion transforms would override them anyway).
-- Copy success swaps the icon with a spring pop (`scale 0.4 → 1`, slight overshoot) via `AnimatePresence mode="wait"`.
+- Copy success crossfades the icon/label in place — both states share one grid cell and animate opacity + scale simultaneously (150ms, `cubic-bezier(0.34, 1.56, 0.64, 1)` for a slight overshoot). Never serialize exit-then-enter here (no `AnimatePresence mode="wait"`); it leaves a dead gap with nothing visible.
 - The install provider tabs slide their indicator (`layoutId`) and cross-slide the command area on switch.
 - Card hover lift is `whileHover={{ y: -4 }}` (Motion-driven, not a CSS transform, so it composes with layout animations).
 - Theme switching transitions colors globally (200ms on background/border/color/fill/stroke/box-shadow via a `@layer base` rule that utilities can override).

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -8,7 +8,7 @@
   </defs>
   <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#brand-gradient)" />
   <path
-    d="M13 27.5v-15h9.5M13 20.5h7.5"
+    d="M11 27.5v-15h7M11 20.5h5.5"
     fill="none"
     stroke="#fff"
     stroke-width="2.4"
@@ -16,7 +16,7 @@
     stroke-linejoin="round"
   />
   <path
-    d="M28.5 13.5h-5c-2.3 0-3.5 1.1-3.5 2.8 0 4.2 8.5 2.3 8.5 7.4 0 2.6-2 4-5.2 4h-4.8"
+    d="M30 13.5h-4.2c-2 0-3 1-3 2.6 0 3.9 7.2 2.1 7.2 6.6 0 2.3-1.7 3.6-4.4 3.6h-4.1"
     fill="none"
     stroke="#fff"
     stroke-width="2.4"

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,27 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" role="img" aria-labelledby="title">
   <title id="title">Flc's Skills</title>
-  <style>
-    .tile { fill: #e95545; }
-    @media (prefers-color-scheme: dark) {
-      .tile { fill: #ff715b; }
-    }
-  </style>
-  <path d="M7 7h27l4 4v27H11l-4-4V7Z" fill="#0b1825" />
-  <path class="tile" d="M2 2h27l4 4v27H6l-4-4V2Z" />
+  <defs>
+    <linearGradient id="brand-gradient" x1="4" y1="2" x2="36" y2="38" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF9A6B" />
+      <stop offset="1" stop-color="#FF5722" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#brand-gradient)" />
   <path
-    d="M8.5 25v-15h9.25m-9.25 7h7.25"
+    d="M13 27.5v-15h9.5M13 20.5h7.5"
     fill="none"
     stroke="#fff"
-    stroke-width="2"
-    stroke-linecap="square"
-    stroke-linejoin="miter"
+    stroke-width="2.4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
   />
   <path
-    d="M27 10.5h-4.75c-2.1 0-3.25 1.05-3.25 2.65 0 4.1 8 2.15 8 7.2 0 2.85-2 4.65-5.15 4.65H18"
+    d="M28.5 13.5h-5c-2.3 0-3.5 1.1-3.5 2.8 0 4.2 8.5 2.3 8.5 7.4 0 2.6-2 4-5.2 4h-4.8"
     fill="none"
     stroke="#fff"
-    stroke-width="2"
-    stroke-linecap="square"
-    stroke-linejoin="miter"
+    stroke-width="2.4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
   />
 </svg>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -101,6 +101,21 @@ a {
   background: color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  cursor: pointer;
+  background: var(--muted);
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2.6" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>') center / contain no-repeat;
+  transition: background 0.15s ease;
+}
+
+input[type="search"]::-webkit-search-cancel-button:hover {
+  background: var(--accent);
+}
+
 .font-display {
   font-family: var(--font-jakarta), var(--font-inter), ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -15,15 +15,15 @@
   --muted: #68707f;
   --border: rgba(27, 30, 40, 0.08);
   --border-strong: rgba(27, 30, 40, 0.14);
-  --accent: #6366f1;
-  --accent-strong: #4f46e5;
-  --accent-soft: rgba(99, 102, 241, 0.1);
+  --accent: #ff5c33;
+  --accent-strong: #e84620;
+  --accent-soft: rgba(255, 92, 51, 0.1);
   --on-accent: #ffffff;
   --header: rgba(250, 249, 247, 0.78);
   --shadow-card: 0 1px 2px rgba(27, 30, 40, 0.05), 0 10px 30px -14px rgba(27, 30, 40, 0.14);
-  --shadow-card-hover: 0 2px 4px rgba(27, 30, 40, 0.06), 0 20px 44px -16px rgba(79, 70, 229, 0.22);
+  --shadow-card-hover: 0 2px 4px rgba(27, 30, 40, 0.06), 0 20px 44px -16px rgba(255, 92, 51, 0.28);
   --shadow-modal: 0 24px 70px -12px rgba(27, 30, 40, 0.3);
-  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(99, 102, 241, 0.13), transparent 70%);
+  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(255, 92, 51, 0.12), transparent 70%);
 }
 
 .dark {
@@ -34,15 +34,15 @@
   --muted: #9aa2b1;
   --border: rgba(242, 243, 247, 0.09);
   --border-strong: rgba(242, 243, 247, 0.16);
-  --accent: #818cf8;
-  --accent-strong: #a5b4fc;
-  --accent-soft: rgba(129, 140, 248, 0.14);
-  --on-accent: #12131f;
+  --accent: #ff8a66;
+  --accent-strong: #ffa585;
+  --accent-soft: rgba(255, 138, 102, 0.16);
+  --on-accent: #2a1309;
   --header: rgba(14, 15, 19, 0.72);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -14px rgba(0, 0, 0, 0.5);
-  --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.35), 0 22px 48px -16px rgba(99, 102, 241, 0.32);
+  --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.35), 0 22px 48px -16px rgba(255, 138, 102, 0.32);
   --shadow-modal: 0 24px 70px -12px rgba(0, 0, 0, 0.65);
-  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(129, 140, 248, 0.15), transparent 70%);
+  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(255, 138, 102, 0.14), transparent 70%);
 }
 
 html {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -8,33 +8,41 @@
 }
 
 :root {
-  --background: #e7eef5;
-  --foreground: #0b1825;
-  --surface: #f6f9fc;
-  --surface-muted: #dce7ef;
-  --muted: #526a7e;
-  --rule: rgba(32, 56, 76, 0.18);
-  --rule-strong: rgba(32, 56, 76, 0.34);
-  --accent: #e95545;
-  --accent-strong: #c83f33;
-  --signal: #147f91;
-  --shadow-station: 0 32px 90px -46px rgba(18, 40, 60, 0.42);
-  --header: rgba(231, 238, 245, 0.88);
+  --background: #faf9f7;
+  --surface: #ffffff;
+  --surface-muted: #f1f0ee;
+  --foreground: #1b1e28;
+  --muted: #68707f;
+  --border: rgba(27, 30, 40, 0.08);
+  --border-strong: rgba(27, 30, 40, 0.14);
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.1);
+  --on-accent: #ffffff;
+  --header: rgba(250, 249, 247, 0.78);
+  --shadow-card: 0 1px 2px rgba(27, 30, 40, 0.05), 0 10px 30px -14px rgba(27, 30, 40, 0.14);
+  --shadow-card-hover: 0 2px 4px rgba(27, 30, 40, 0.06), 0 20px 44px -16px rgba(79, 70, 229, 0.22);
+  --shadow-modal: 0 24px 70px -12px rgba(27, 30, 40, 0.3);
+  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(99, 102, 241, 0.13), transparent 70%);
 }
 
 .dark {
-  --background: #07101e;
-  --foreground: #eef6ff;
-  --surface: #0d1b2e;
-  --surface-muted: #102238;
-  --muted: #8fa4ba;
-  --rule: rgba(158, 190, 220, 0.18);
-  --rule-strong: rgba(158, 190, 220, 0.34);
-  --accent: #ff715b;
-  --accent-strong: #ff8a78;
-  --signal: #70d7e5;
-  --shadow-station: 0 34px 90px -34px rgba(0, 0, 0, 0.58);
-  --header: rgba(7, 16, 30, 0.88);
+  --background: #0e0f13;
+  --surface: #17181e;
+  --surface-muted: #1f2129;
+  --foreground: #f2f3f7;
+  --muted: #9aa2b1;
+  --border: rgba(242, 243, 247, 0.09);
+  --border-strong: rgba(242, 243, 247, 0.16);
+  --accent: #818cf8;
+  --accent-strong: #a5b4fc;
+  --accent-soft: rgba(129, 140, 248, 0.14);
+  --on-accent: #12131f;
+  --header: rgba(14, 15, 19, 0.72);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -14px rgba(0, 0, 0, 0.5);
+  --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.35), 0 22px 48px -16px rgba(99, 102, 241, 0.32);
+  --shadow-modal: 0 24px 70px -12px rgba(0, 0, 0, 0.65);
+  --glow: radial-gradient(ellipse 60% 44% at 50% -6%, rgba(129, 140, 248, 0.15), transparent 70%);
 }
 
 html {
@@ -45,11 +53,8 @@ body {
   min-height: 100vh;
   overflow-x: hidden;
   color: var(--foreground);
-  background:
-    radial-gradient(circle at 82% 10%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 24rem),
-    radial-gradient(circle at 62% 36%, color-mix(in srgb, var(--signal) 7%, transparent), transparent 28rem),
-    linear-gradient(180deg, var(--background), color-mix(in srgb, var(--background) 92%, var(--surface-muted)));
-  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--background);
+  font-family: var(--font-inter), ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   text-rendering: optimizeLegibility;
 }
 
@@ -59,12 +64,7 @@ body::before {
   z-index: -1;
   content: "";
   pointer-events: none;
-  opacity: 0.58;
-  background-image:
-    linear-gradient(color-mix(in srgb, var(--rule) 42%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--rule) 42%, transparent) 1px, transparent 1px);
-  background-size: 80px 80px;
-  mask-image: linear-gradient(to bottom, black 0 66%, transparent 94%);
+  background: var(--glow);
 }
 
 button,
@@ -77,23 +77,18 @@ a {
   -webkit-tap-highlight-color: transparent;
 }
 
-button:active,
-a:active {
-  transform: translateY(1px);
-}
-
 :focus-visible {
-  outline: 2px solid var(--signal);
+  outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
 
 ::selection {
   color: var(--foreground);
-  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  background: color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 .font-display {
-  font-family: "Avenir Next", Avenir, "Century Gothic", "Trebuchet MS", "Segoe UI", sans-serif;
+  font-family: var(--font-jakarta), var(--font-inter), ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .font-mono,
@@ -102,63 +97,8 @@ pre {
   font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
 }
 
-.signal-orbit {
-  position: absolute;
-  top: 2.5rem;
-  right: -2rem;
-  width: min(44vw, 36rem);
-  height: 18rem;
-  pointer-events: none;
-  border-top: 1px solid color-mix(in srgb, var(--signal) 48%, transparent);
-  border-right: 1px solid color-mix(in srgb, var(--signal) 18%, transparent);
-  border-radius: 0 18rem 0 0;
-  transform: skewY(-7deg);
-  opacity: 0.6;
-}
-
-.signal-orbit::before,
-.signal-orbit::after {
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  content: "";
-  border: 1px solid var(--accent);
-  border-radius: 999px;
-  background: var(--background);
-  box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 70%, transparent);
-}
-
-.signal-orbit::before {
-  top: -4px;
-  left: 6rem;
-}
-
-.signal-orbit::after {
-  top: 8rem;
-  right: -4px;
-}
-
-.catalog-band {
-  --catalog-background: color-mix(in srgb, var(--surface) 94%, var(--background));
-  position: relative;
-  isolation: isolate;
-}
-
-.catalog-band::before {
-  position: absolute;
-  inset: 0 calc(50% - 50vw);
-  z-index: -1;
-  content: "";
-  background: linear-gradient(
-    to bottom,
-    transparent 0,
-    var(--catalog-background) 3rem,
-    var(--catalog-background) 100%
-  );
-}
-
 .custom-scrollbar::-webkit-scrollbar {
-  width: 6px;
+  width: 8px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-track {
@@ -166,17 +106,8 @@ pre {
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--muted) 42%, transparent);
-}
-
-@media (max-width: 767px) {
-  body::before {
-    background-size: 48px 48px;
-  }
-
-  .signal-orbit {
-    display: none;
-  }
+  background: color-mix(in srgb, var(--muted) 36%, transparent);
+  border-radius: 999px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -78,6 +78,18 @@ a {
 }
 
 @layer base {
+  *,
+  *::before,
+  *::after {
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease,
+      fill 0.2s ease,
+      stroke 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+
   :focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 3px;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -77,9 +77,11 @@ a {
   -webkit-tap-highlight-color: transparent;
 }
 
-:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
+@layer base {
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
 }
 
 ::selection {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,11 +2,24 @@ import type { Metadata } from "next";
 import { Suspense } from 'react';
 import Link from 'next/link';
 import Script from 'next/script';
+import { Inter, Plus_Jakarta_Sans } from 'next/font/google';
 import { GaPageViewTracker } from '@/components/GaPageViewTracker';
 import { GithubNavLink } from '@/components/GithubNavLink';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { BrandMark } from '@/components/BrandMark';
 import "./globals.css";
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-jakarta',
+  display: 'swap',
+});
 
 const GA_MEASUREMENT_ID = 'G-GYPECK2498';
 
@@ -42,7 +55,7 @@ export default function RootLayout({
   `;
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={`${inter.variable} ${jakarta.variable}`} suppressHydrationWarning>
       <head>
         <Script
           src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
@@ -63,37 +76,33 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <GaPageViewTracker />
         </Suspense>
-        <header className="fixed inset-x-0 top-0 z-40 border-b border-[var(--rule)] bg-[var(--header)] backdrop-blur-xl">
-          <div className="mx-auto flex h-20 max-w-[1360px] items-center justify-between px-5 sm:px-8 lg:px-10">
+        <header className="fixed inset-x-0 top-0 z-40 border-b border-[var(--border)] bg-[var(--header)] backdrop-blur-xl">
+          <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5 sm:px-8">
             <Link
               href="/"
-              className="group flex min-w-0 items-center gap-4 outline-none transition-opacity hover:opacity-80"
+              className="group flex min-w-0 items-center gap-3 outline-none transition-opacity hover:opacity-80"
               aria-label="Go to homepage"
             >
-              <BrandMark className="h-9 w-9 shrink-0" />
-              <span className="font-display min-w-0 text-lg font-extrabold tracking-[-0.03em] text-[var(--foreground)] sm:text-xl">
+              <BrandMark className="h-8 w-8 shrink-0" />
+              <span className="font-display min-w-0 text-lg font-bold tracking-tight text-[var(--foreground)]">
                 Flc&apos;s Skills
               </span>
             </Link>
-            <nav>
-              <div className="grid h-9 w-[73px] grid-cols-2 divide-x divide-[var(--rule)] border border-[var(--rule-strong)] bg-[color-mix(in_srgb,var(--surface)_58%,transparent)]">
-                <ThemeToggle />
-                <GithubNavLink />
-              </div>
+            <nav className="flex items-center gap-2">
+              <ThemeToggle />
+              <GithubNavLink />
             </nav>
           </div>
         </header>
-        <main className="pt-20">{children}</main>
-        <footer className="border-t border-[var(--rule)] bg-[color-mix(in_srgb,var(--surface)_74%,transparent)] py-10">
-          <div className="mx-auto grid max-w-[1360px] gap-6 px-5 sm:px-8 md:grid-cols-[1fr_auto] md:items-end lg:px-10">
-            <div>
-              <p className="font-display mb-2 text-lg font-extrabold tracking-[-0.02em] text-[var(--foreground)]">Flc&apos;s Skills</p>
-              <p className="max-w-xl text-sm leading-6 text-[var(--muted)]">
-                Reusable workflow skills for agents that need clearer operating rules and repeatable outcomes.
-              </p>
-            </div>
-            <p className="text-xs text-[var(--muted)]">
-              © 2026 Flc&apos;s Skills. Created by{' '}
+        <main className="pt-16">{children}</main>
+        <footer className="mt-24 border-t border-[var(--border)] py-10">
+          <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-5 text-center sm:px-8">
+            <p className="font-display text-sm font-bold text-[var(--foreground)]">Flc&apos;s Skills</p>
+            <p className="max-w-md text-xs leading-5 text-[var(--muted)]">
+              Reusable workflow skills for agents that need clearer operating rules and repeatable outcomes.
+            </p>
+            <p className="mt-2 text-xs text-[var(--muted)]">
+              © 2026{' '}
               <a
                 href="https://flc.io"
                 target="_blank"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -8,11 +8,16 @@ export default async function Home() {
   return (
     <div className="min-h-screen">
       <Suspense fallback={
-        <div className="mx-auto max-w-[1360px] px-5 py-24 sm:px-8 lg:px-10">
-          <div className="animate-pulse border-y border-[var(--rule)] py-16">
-            <div className="mb-5 h-3 w-28 bg-[var(--surface-muted)]"></div>
-            <div className="mb-3 h-12 w-3/5 bg-[var(--surface-muted)]"></div>
-            <div className="h-12 w-2/5 bg-[var(--surface-muted)]"></div>
+        <div className="mx-auto max-w-6xl px-5 py-24 sm:px-8">
+          <div className="mx-auto flex max-w-3xl animate-pulse flex-col items-center">
+            <div className="mb-4 h-12 w-3/5 rounded-2xl bg-[var(--surface-muted)]"></div>
+            <div className="mb-10 h-12 w-2/5 rounded-2xl bg-[var(--surface-muted)]"></div>
+            <div className="h-14 w-full max-w-xl rounded-full bg-[var(--surface-muted)]"></div>
+          </div>
+          <div className="mt-20 grid animate-pulse gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {[0, 1, 2, 3, 4, 5].map((item) => (
+              <div key={item} className="h-36 rounded-2xl bg-[var(--surface-muted)]"></div>
+            ))}
           </div>
         </div>
       }>

--- a/web/src/components/BrandMark.tsx
+++ b/web/src/components/BrandMark.tsx
@@ -13,8 +13,8 @@ export function BrandMark({ className }: BrandMarkProps) {
     >
       <defs>
         <linearGradient id="brand-gradient" x1="4" y1="2" x2="36" y2="38" gradientUnits="userSpaceOnUse">
-          <stop stopColor="#818CF8" />
-          <stop offset="1" stopColor="#6366F1" />
+          <stop stopColor="#FF9A6B" />
+          <stop offset="1" stopColor="#FF5722" />
         </linearGradient>
       </defs>
       <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#brand-gradient)" />

--- a/web/src/components/BrandMark.tsx
+++ b/web/src/components/BrandMark.tsx
@@ -11,21 +11,26 @@ export function BrandMark({ className }: BrandMarkProps) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path d="M7 7h27l4 4v27H11l-4-4V7Z" fill="#0B1825" />
-      <path d="M2 2h27l4 4v27H6l-4-4V2Z" fill="var(--accent)" />
+      <defs>
+        <linearGradient id="brand-gradient" x1="4" y1="2" x2="36" y2="38" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#818CF8" />
+          <stop offset="1" stopColor="#6366F1" />
+        </linearGradient>
+      </defs>
+      <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#brand-gradient)" />
       <path
-        d="M8.5 25v-15h9.25m-9.25 7h7.25"
+        d="M13 27.5v-15h9.5M13 20.5h7.5"
         stroke="#fff"
-        strokeWidth="2"
-        strokeLinecap="square"
-        strokeLinejoin="miter"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
-        d="M27 10.5h-4.75c-2.1 0-3.25 1.05-3.25 2.65 0 4.1 8 2.15 8 7.2 0 2.85-2 4.65-5.15 4.65H18"
+        d="M28.5 13.5h-5c-2.3 0-3.5 1.1-3.5 2.8 0 4.2 8.5 2.3 8.5 7.4 0 2.6-2 4-5.2 4h-4.8"
         stroke="#fff"
-        strokeWidth="2"
-        strokeLinecap="square"
-        strokeLinejoin="miter"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/web/src/components/BrandMark.tsx
+++ b/web/src/components/BrandMark.tsx
@@ -19,14 +19,14 @@ export function BrandMark({ className }: BrandMarkProps) {
       </defs>
       <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#brand-gradient)" />
       <path
-        d="M13 27.5v-15h9.5M13 20.5h7.5"
+        d="M11 27.5v-15h7M11 20.5h5.5"
         stroke="#fff"
         strokeWidth="2.4"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
-        d="M28.5 13.5h-5c-2.3 0-3.5 1.1-3.5 2.8 0 4.2 8.5 2.3 8.5 7.4 0 2.6-2 4-5.2 4h-4.8"
+        d="M30 13.5h-4.2c-2 0-3 1-3 2.6 0 3.9 7.2 2.1 7.2 6.6 0 2.3-1.7 3.6-4.4 3.6h-4.1"
         stroke="#fff"
         strokeWidth="2.4"
         strokeLinecap="round"

--- a/web/src/components/GithubNavLink.tsx
+++ b/web/src/components/GithubNavLink.tsx
@@ -19,9 +19,9 @@ export function GithubNavLink() {
           location: 'header',
         });
       }}
-      className="grid h-full w-full place-items-center text-[var(--muted)] transition-colors hover:bg-[color-mix(in_srgb,var(--surface-muted)_48%,transparent)] hover:text-[var(--foreground)]"
+      className="grid h-9 w-9 place-items-center rounded-full text-[var(--muted)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--foreground)]"
     >
-      <Icons.Github size={15} />
+      <Icons.Github size={16} />
     </a>
   );
 }

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -212,7 +212,8 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
           A curated collection of reusable agent skills—turn repeatable engineering, research, and knowledge tasks into one-command workflows.
         </motion.p>
 
-        <motion.div variants={heroItem} className="mx-auto mt-9 flex h-14 max-w-xl items-center rounded-full border border-[var(--border)] bg-[var(--surface)] pl-5 pr-2 shadow-[var(--shadow-card)] transition-[border-color,box-shadow] focus-within:border-[color-mix(in_srgb,var(--accent)_45%,var(--border))] focus-within:shadow-[var(--shadow-card-hover)]">
+        <motion.div variants={heroItem} className="mx-auto mt-9 max-w-xl">
+          <div className="flex h-14 items-center rounded-full border border-[var(--border)] bg-[var(--surface)] pl-5 pr-2 shadow-[var(--shadow-card)] transition-[border-color,box-shadow,scale] duration-200 focus-within:scale-[1.02] focus-within:border-[color-mix(in_srgb,var(--accent)_45%,var(--border))] focus-within:shadow-[var(--shadow-card-hover)]">
           <Search size={18} strokeWidth={1.8} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
           <label htmlFor="skill-search" className="sr-only">Search catalog</label>
           <input
@@ -225,6 +226,7 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
             onChange={(event) => setSearch(event.target.value)}
           />
           <span className="hidden h-9 shrink-0 items-center rounded-full bg-[var(--surface-muted)] px-3 font-mono text-[11px] text-[var(--muted)] sm:flex">⌘ K</span>
+          </div>
         </motion.div>
 
         <motion.div variants={heroItem} className="mt-6 flex flex-wrap items-center justify-center gap-2" aria-label="Collection facts">

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -169,71 +169,60 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
   };
 
   return (
-    <div className="relative mx-auto max-w-[1360px] px-5 sm:px-8 lg:px-10">
-      <section className="relative grid min-h-[42rem] gap-10 border-b border-[var(--rule)] py-12 md:grid-cols-[minmax(0,1.08fr)_minmax(22rem,0.92fr)] md:items-center lg:gap-16 lg:py-14">
-        <div className="signal-orbit" aria-hidden="true" />
+    <div className="mx-auto max-w-6xl px-5 sm:px-8">
+      <section className="mx-auto max-w-3xl pb-14 pt-16 text-center sm:pt-24">
+        <h1 className="font-display text-[clamp(2.6rem,6vw,4.25rem)] font-extrabold leading-[1.05] tracking-tight text-[var(--foreground)]">
+          Find your next
+          <span className="text-[var(--accent)]"> workflow.</span>
+        </h1>
+        <p className="mx-auto mt-5 max-w-xl text-base leading-7 text-[var(--muted)] sm:text-lg sm:leading-8">
+          A curated collection of reusable agent skills—turn repeatable engineering, research, and knowledge tasks into one-command workflows.
+        </p>
 
-        <div className="relative z-10 min-w-0 max-w-3xl">
-          <h1 className="font-display text-[clamp(3.4rem,5.2vw,5rem)] font-extrabold leading-[0.94] tracking-[-0.06em] text-[var(--foreground)]">
-            Find the right skill.
-            <br />
-            Start with the <span className="text-[var(--accent)]">exact workflow.</span>
-          </h1>
-          <p className="mt-7 max-w-[38rem] text-base leading-8 text-[var(--muted)] sm:text-lg">
-            A curated atlas of reusable agent workflows—built to turn repeatable engineering, research, and knowledge tasks into precise operating systems.
-          </p>
-
-          <div className="mt-8 flex h-16 max-w-[38rem] items-center border border-[var(--rule-strong)] bg-[color-mix(in_srgb,var(--background)_82%,transparent)] shadow-[0_20px_55px_-34px_rgba(0,0,0,0.55)]">
-            <span className="grid h-full w-16 shrink-0 place-items-center border-r border-[var(--rule)] text-[var(--signal)]" aria-hidden="true">
-              <Search size={20} strokeWidth={1.5} />
-            </span>
-            <label htmlFor="skill-search" className="sr-only">Search catalog</label>
-            <input
-              ref={searchInputRef}
-              id="skill-search"
-              type="search"
-              placeholder="Search skills by name or workflow"
-              className="h-full min-w-0 flex-1 bg-transparent px-4 text-sm font-medium text-[var(--foreground)] outline-none placeholder:text-[var(--muted)] sm:text-base"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-            />
-            <span className="hidden h-full shrink-0 place-items-center border-l border-[var(--rule)] px-4 font-mono text-[11px] text-[var(--muted)] sm:grid">⌘ K</span>
-          </div>
-
-          <div className="mt-7 flex flex-wrap gap-x-10 gap-y-3" aria-label="Collection facts">
-            <div className="flex items-baseline gap-3">
-              <strong className="font-display text-2xl font-extrabold text-[var(--accent)]">{totalSkills}</strong>
-              <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--muted)]">skills mapped</span>
-            </div>
-            <div className="flex items-baseline gap-3">
-              <strong className="font-display text-2xl font-extrabold text-[var(--accent)]">{totalFiles}</strong>
-              <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--muted)]">source files</span>
-            </div>
-          </div>
+        <div className="mx-auto mt-9 flex h-14 max-w-xl items-center rounded-full border border-[var(--border)] bg-[var(--surface)] pl-5 pr-2 shadow-[var(--shadow-card)] transition-[border-color,box-shadow] focus-within:border-[color-mix(in_srgb,var(--accent)_45%,var(--border))] focus-within:shadow-[var(--shadow-card-hover)]">
+          <Search size={18} strokeWidth={1.8} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
+          <label htmlFor="skill-search" className="sr-only">Search catalog</label>
+          <input
+            ref={searchInputRef}
+            id="skill-search"
+            type="search"
+            placeholder="Search skills by name or workflow"
+            className="h-full min-w-0 flex-1 bg-transparent px-3 text-sm text-[var(--foreground)] outline-none placeholder:text-[var(--muted)] sm:text-base"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <span className="hidden h-9 shrink-0 items-center rounded-full bg-[var(--surface-muted)] px-3 font-mono text-[11px] text-[var(--muted)] sm:flex">⌘ K</span>
         </div>
 
-        <div className="relative z-10 min-w-0">
-          <RepositoryInstallPanel />
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-2" aria-label="Collection facts">
+          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
+            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]">{totalSkills}</strong> skills
+          </span>
+          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
+            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]">{totalFiles}</strong> source files
+          </span>
+          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
+            One command to install
+          </span>
         </div>
       </section>
 
-      <section className="catalog-band py-12 sm:py-16" aria-labelledby="catalog-heading">
-        <div className="grid gap-4 border-b border-[var(--rule-strong)] pb-5 sm:grid-cols-[1fr_auto] sm:items-end">
-          <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
-            <h2 id="catalog-heading" className="font-display text-4xl font-extrabold tracking-[-0.045em] text-[var(--foreground)]">
-              Browse skills
-            </h2>
-            <p className="text-sm text-[var(--muted)]" aria-live="polite">
-              {String(orderedSkills.length).padStart(2, '0')} visible records
-            </p>
-          </div>
-          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--muted)]">
-            Newest signal first
+      <section className="mx-auto max-w-2xl pb-16">
+        <RepositoryInstallPanel />
+      </section>
+
+      <section className="pb-8" aria-labelledby="catalog-heading">
+        <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+          <h2 id="catalog-heading" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
+            Browse skills
+          </h2>
+          <p className="text-sm text-[var(--muted)]" aria-live="polite">
+            {orderedSkills.length} {orderedSkills.length === 1 ? 'skill' : 'skills'} · newest first
           </p>
         </div>
 
         <MotionConfig reducedMotion="user">
-          <div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <AnimatePresence mode="popLayout">
               {orderedSkills.map((skill, index) => (
                 <SkillCard
@@ -248,11 +237,13 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
         </MotionConfig>
 
         {orderedSkills.length === 0 ? (
-          <div className="border-b border-[var(--rule)] py-16">
-            <div className="mb-5 h-2 w-2 rotate-45 border border-[var(--accent)] shadow-[0_0_14px_color-mix(in_srgb,var(--accent)_60%,transparent)]" />
-            <h3 className="font-display text-2xl font-extrabold tracking-[-0.03em] text-[var(--foreground)]">No matching signal</h3>
-            <p className="mt-2 max-w-md text-sm leading-6 text-[var(--muted)]">
-              Try a broader workflow, tool, or outcome to restore the atlas.
+          <div className="flex flex-col items-center rounded-2xl border border-dashed border-[var(--border-strong)] py-16 text-center">
+            <span className="grid h-11 w-11 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)]">
+              <Search size={18} strokeWidth={1.8} />
+            </span>
+            <h3 className="font-display mt-4 text-lg font-bold text-[var(--foreground)]">No matching skills</h3>
+            <p className="mt-1 max-w-sm text-sm leading-6 text-[var(--muted)]">
+              Try a broader workflow, tool, or outcome.
             </p>
           </div>
         ) : null}

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -268,15 +268,25 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
         </div>
 
         {orderedSkills.length === 0 ? (
-          <div className="flex flex-col items-center rounded-2xl border border-dashed border-[var(--border-strong)] py-16 text-center">
-            <span className="grid h-11 w-11 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)]">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, ease: 'easeOut' }}
+            className="flex flex-col items-center rounded-2xl border border-dashed border-[var(--border-strong)] py-16 text-center"
+          >
+            <motion.span
+              initial={{ scale: 0.4, rotate: -14 }}
+              animate={{ scale: 1, rotate: 0 }}
+              transition={{ type: 'spring', stiffness: 320, damping: 13, delay: 0.08 }}
+              className="grid h-11 w-11 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)]"
+            >
               <Search size={18} strokeWidth={1.8} />
-            </span>
+            </motion.span>
             <h3 className="font-display mt-4 text-lg font-bold text-[var(--foreground)]">No matching skills</h3>
             <p className="mt-1 max-w-sm text-sm leading-6 text-[var(--muted)]">
               Try a broader workflow, tool, or outcome.
             </p>
-          </div>
+          </motion.div>
         ) : null}
       </section>
 

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { AnimatePresence, MotionConfig } from 'motion/react';
+import { AnimatePresence, MotionConfig, animate, motion, useMotionValue, useReducedMotion, useTransform } from 'motion/react';
+import type { Variants } from 'motion/react';
 import { Search } from 'lucide-react';
 import { RepositoryInstallPanel } from './RepositoryInstallPanel';
 import { SkillCard } from './SkillCard';
@@ -24,6 +25,32 @@ function compareSkillsByCreated(left: SkillMetadata, right: SkillMetadata) {
   }
 
   return left.name.localeCompare(right.name);
+}
+
+const heroContainer: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.07, delayChildren: 0.05 } },
+};
+
+const heroItem: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { type: 'spring', stiffness: 240, damping: 26 } },
+};
+
+function AnimatedNumber({ value }: { value: number }) {
+  const shouldReduceMotion = useReducedMotion();
+  const motionValue = useMotionValue(0);
+  const rounded = useTransform(motionValue, (latest) => Math.round(latest));
+
+  useEffect(() => {
+    const controls = animate(motionValue, value, {
+      duration: shouldReduceMotion ? 0 : 0.7,
+      ease: 'easeOut',
+    });
+    return () => controls.stop();
+  }, [motionValue, shouldReduceMotion, value]);
+
+  return <motion.span>{rounded}</motion.span>;
 }
 
 export function Marketplace({ initialSkills }: MarketplaceProps) {
@@ -169,17 +196,23 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
   };
 
   return (
-    <div className="mx-auto max-w-6xl px-5 sm:px-8">
+    <MotionConfig reducedMotion="user">
+    <motion.div
+      variants={heroContainer}
+      initial="hidden"
+      animate="show"
+      className="mx-auto max-w-6xl px-5 sm:px-8"
+    >
       <section className="mx-auto max-w-3xl pb-14 pt-16 text-center sm:pt-24">
-        <h1 className="font-display text-[clamp(2.6rem,6vw,4.25rem)] font-extrabold leading-[1.05] tracking-tight text-[var(--foreground)]">
+        <motion.h1 variants={heroItem} className="font-display text-[clamp(2.6rem,6vw,4.25rem)] font-extrabold leading-[1.05] tracking-tight text-[var(--foreground)]">
           Find your next
           <span className="text-[var(--accent)]"> workflow.</span>
-        </h1>
-        <p className="mx-auto mt-5 max-w-xl text-base leading-7 text-[var(--muted)] sm:text-lg sm:leading-8">
+        </motion.h1>
+        <motion.p variants={heroItem} className="mx-auto mt-5 max-w-xl text-base leading-7 text-[var(--muted)] sm:text-lg sm:leading-8">
           A curated collection of reusable agent skills—turn repeatable engineering, research, and knowledge tasks into one-command workflows.
-        </p>
+        </motion.p>
 
-        <div className="mx-auto mt-9 flex h-14 max-w-xl items-center rounded-full border border-[var(--border)] bg-[var(--surface)] pl-5 pr-2 shadow-[var(--shadow-card)] transition-[border-color,box-shadow] focus-within:border-[color-mix(in_srgb,var(--accent)_45%,var(--border))] focus-within:shadow-[var(--shadow-card-hover)]">
+        <motion.div variants={heroItem} className="mx-auto mt-9 flex h-14 max-w-xl items-center rounded-full border border-[var(--border)] bg-[var(--surface)] pl-5 pr-2 shadow-[var(--shadow-card)] transition-[border-color,box-shadow] focus-within:border-[color-mix(in_srgb,var(--accent)_45%,var(--border))] focus-within:shadow-[var(--shadow-card-hover)]">
           <Search size={18} strokeWidth={1.8} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
           <label htmlFor="skill-search" className="sr-only">Search catalog</label>
           <input
@@ -192,24 +225,24 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
             onChange={(event) => setSearch(event.target.value)}
           />
           <span className="hidden h-9 shrink-0 items-center rounded-full bg-[var(--surface-muted)] px-3 font-mono text-[11px] text-[var(--muted)] sm:flex">⌘ K</span>
-        </div>
+        </motion.div>
 
-        <div className="mt-6 flex flex-wrap items-center justify-center gap-2" aria-label="Collection facts">
+        <motion.div variants={heroItem} className="mt-6 flex flex-wrap items-center justify-center gap-2" aria-label="Collection facts">
           <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
-            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]">{totalSkills}</strong> skills
+            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]"><AnimatedNumber value={totalSkills} /></strong> skills
           </span>
           <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
-            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]">{totalFiles}</strong> source files
+            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]"><AnimatedNumber value={totalFiles} /></strong> source files
           </span>
           <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
             One command to install
           </span>
-        </div>
+        </motion.div>
       </section>
 
-      <section className="mx-auto max-w-2xl pb-16">
+      <motion.section variants={heroItem} className="mx-auto max-w-2xl pb-16">
         <RepositoryInstallPanel />
-      </section>
+      </motion.section>
 
       <section className="pb-8" aria-labelledby="catalog-heading">
         <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
@@ -221,20 +254,18 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
           </p>
         </div>
 
-        <MotionConfig reducedMotion="user">
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <AnimatePresence mode="popLayout">
-              {orderedSkills.map((skill, index) => (
-                <SkillCard
-                  key={skill.slug}
-                  skill={skill}
-                  position={index + 1}
-                  onClick={handleCardClick}
-                />
-              ))}
-            </AnimatePresence>
-          </div>
-        </MotionConfig>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <AnimatePresence mode="popLayout">
+            {orderedSkills.map((skill, index) => (
+              <SkillCard
+                key={skill.slug}
+                skill={skill}
+                position={index + 1}
+                onClick={handleCardClick}
+              />
+            ))}
+          </AnimatePresence>
+        </div>
 
         {orderedSkills.length === 0 ? (
           <div className="flex flex-col items-center rounded-2xl border border-dashed border-[var(--border-strong)] py-16 text-center">
@@ -256,6 +287,7 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
         error={skillLoadError}
         onClose={handleCloseModal}
       />
-    </div>
+    </motion.div>
+    </MotionConfig>
   );
 }

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -152,6 +152,7 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
   }, [initialSkills, search]);
 
   const totalSkills = initialSkills.length;
+  const isSearching = search.trim().length > 0;
   const totalFiles = useMemo(
     () => initialSkills.reduce((sum, skill) => sum + skill.fileCount, 0),
     [initialSkills]
@@ -242,8 +243,21 @@ export function Marketplace({ initialSkills }: MarketplaceProps) {
         </motion.div>
       </section>
 
-      <motion.section variants={heroItem} className="mx-auto max-w-2xl pb-16">
-        <RepositoryInstallPanel />
+      <motion.section variants={heroItem} className="mx-auto max-w-2xl">
+        <AnimatePresence initial={false}>
+          {!isSearching && (
+            <motion.div
+              key="quick-install-panel"
+              initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+              animate={{ opacity: 1, height: 'auto', marginBottom: 64 }}
+              exit={{ opacity: 0, height: 0, marginBottom: 0, transition: { duration: 0.2, ease: [0.32, 0.72, 0, 1] } }}
+              transition={{ duration: 0.28, ease: [0.32, 0.72, 0, 1] }}
+              className="overflow-hidden"
+            >
+              <RepositoryInstallPanel />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </motion.section>
 
       <section className="pb-8" aria-labelledby="catalog-heading">

--- a/web/src/components/RepositoryInstallPanel.tsx
+++ b/web/src/components/RepositoryInstallPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { motion } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import { Check, Copy, TerminalSquare } from 'lucide-react';
 import { visibleRepositoryInstallMethods } from '@/lib/install-methods';
 import { trackEvent } from '@/lib/gtag';
@@ -52,11 +52,12 @@ export function RepositoryInstallPanel() {
             const isActive = method.id === activeMethod.id;
 
             return (
-              <button
+              <motion.button
                 key={method.id}
                 type="button"
                 onClick={() => setActiveMethodId(method.id)}
                 aria-pressed={isActive}
+                whileTap={{ scale: 0.94 }}
                 className={`relative rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
                   isActive ? 'text-[var(--foreground)]' : 'text-[var(--muted)] hover:text-[var(--foreground)]'
                 }`}
@@ -69,12 +70,20 @@ export function RepositoryInstallPanel() {
                   />
                 ) : null}
                 <span className="relative">{method.label}</span>
-              </button>
+              </motion.button>
             );
           })}
         </div>
       </div>
 
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={activeMethod.id}
+          initial={{ opacity: 0, x: 14 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -14 }}
+          transition={{ duration: 0.18, ease: 'easeOut' }}
+        >
       {activeMethod.status === 'planned' ? (
         <div className="mt-5 rounded-xl bg-[var(--accent-soft)] px-4 py-4">
           <p className="text-sm font-semibold text-[var(--accent)]">Coming soon</p>
@@ -101,23 +110,48 @@ export function RepositoryInstallPanel() {
                     {entry.command}
                   </code>
                 </div>
-                <button
+                <motion.button
                   type="button"
                   onClick={() => copyCommands(copyKey, entry.command, entry.label)}
-                  className={`grid h-9 w-9 shrink-0 place-items-center rounded-full transition-all ${
+                  whileTap={{ scale: 0.85 }}
+                  className={`grid h-9 w-9 shrink-0 place-items-center rounded-full transition-colors ${
                     isCopied
                       ? 'bg-[var(--accent)] text-[var(--on-accent)]'
                       : 'bg-[var(--surface)] text-[var(--muted)] shadow-[var(--shadow-card)] hover:text-[var(--accent)]'
                   }`}
                   aria-label={`Copy ${entry.label} command`}
                 >
-                  {isCopied ? <Check size={14} /> : <Copy size={14} strokeWidth={1.5} />}
-                </button>
+                  <AnimatePresence mode="wait" initial={false}>
+                    {isCopied ? (
+                      <motion.span
+                        key="copied"
+                        initial={{ scale: 0.4, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        exit={{ scale: 0.4, opacity: 0 }}
+                        transition={{ type: 'spring', stiffness: 500, damping: 22 }}
+                      >
+                        <Check size={14} />
+                      </motion.span>
+                    ) : (
+                      <motion.span
+                        key="copy"
+                        initial={{ scale: 0.4, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        exit={{ scale: 0.4, opacity: 0 }}
+                        transition={{ type: 'spring', stiffness: 300, damping: 24 }}
+                      >
+                        <Copy size={14} strokeWidth={1.5} />
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </motion.button>
               </div>
             );
           })}
         </div>
       )}
+        </motion.div>
+      </AnimatePresence>
     </aside>
   );
 }

--- a/web/src/components/RepositoryInstallPanel.tsx
+++ b/web/src/components/RepositoryInstallPanel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { Check, Copy } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Check, Copy, TerminalSquare } from 'lucide-react';
 import { visibleRepositoryInstallMethods } from '@/lib/install-methods';
 import { trackEvent } from '@/lib/gtag';
 
@@ -40,58 +41,73 @@ export function RepositoryInstallPanel() {
   };
 
   return (
-    <aside className="relative ml-auto w-full max-w-[31rem] border-t border-[color-mix(in_srgb,var(--accent)_68%,transparent)] bg-[color-mix(in_srgb,var(--surface)_94%,transparent)] shadow-[var(--shadow-station)]">
-      <span className="absolute -top-1 left-0 h-2 w-2 bg-[var(--accent)] shadow-[0_0_18px_color-mix(in_srgb,var(--accent)_75%,transparent)]" aria-hidden="true" />
+    <aside className="w-full rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="font-display flex items-center gap-2 text-base font-bold tracking-tight text-[var(--foreground)]">
+          <TerminalSquare size={18} strokeWidth={1.8} className="text-[var(--accent)]" />
+          Quick install
+        </h2>
+        <div className="flex rounded-full bg-[var(--surface-muted)] p-1" aria-label="Install provider">
+          {methods.map((method) => {
+            const isActive = method.id === activeMethod.id;
 
-      <div className="flex min-h-16 flex-col gap-4 border-b border-[var(--rule)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="font-display text-xl font-extrabold tracking-[-0.02em] text-[var(--foreground)]">Install plugin</h2>
-        <div className="grid h-9 w-36 grid-cols-2 divide-x divide-[var(--rule)] border border-[var(--rule-strong)]" aria-label="Install provider">
-          {methods.map((method) => (
-            <button
-              key={method.id}
-              type="button"
-              onClick={() => setActiveMethodId(method.id)}
-              aria-pressed={method.id === activeMethod.id}
-              className={`grid h-full min-w-0 place-items-center px-2 font-mono font-semibold uppercase tracking-[0.12em] transition-colors ${
-                method.id === activeMethod.id
-                  ? 'bg-[color-mix(in_srgb,var(--signal)_9%,transparent)] text-[var(--signal)]'
-                  : 'text-[var(--muted)] hover:bg-[color-mix(in_srgb,var(--surface-muted)_45%,transparent)] hover:text-[var(--foreground)]'
-              }`}
-            >
-              <span className="text-[10px]">{method.label}</span>
-            </button>
-          ))}
+            return (
+              <button
+                key={method.id}
+                type="button"
+                onClick={() => setActiveMethodId(method.id)}
+                aria-pressed={isActive}
+                className={`relative rounded-full px-4 py-1.5 text-xs font-semibold transition-colors ${
+                  isActive ? 'text-[var(--foreground)]' : 'text-[var(--muted)] hover:text-[var(--foreground)]'
+                }`}
+              >
+                {isActive ? (
+                  <motion.span
+                    layoutId="install-provider-indicator"
+                    className="absolute inset-0 rounded-full bg-[var(--surface)] shadow-[var(--shadow-card)]"
+                    transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+                  />
+                ) : null}
+                <span className="relative">{method.label}</span>
+              </button>
+            );
+          })}
         </div>
       </div>
 
       {activeMethod.status === 'planned' ? (
-        <div className="px-5 py-8">
-          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">Signal pending</p>
-          <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+        <div className="mt-5 rounded-xl bg-[var(--accent-soft)] px-4 py-4">
+          <p className="text-sm font-semibold text-[var(--accent)]">Coming soon</p>
+          <p className="mt-1 text-sm leading-6 text-[var(--muted)]">
             Claude plugin support is planned but not available yet. Use the Codex channel for the current install path.
           </p>
         </div>
       ) : (
-        <div>
+        <div className="mt-5 grid gap-3">
           {activeMethod.commands.map((entry, index) => {
             const copyKey = `${activeMethod.id}-${index}`;
             const isCopied = copiedKey === copyKey;
 
             return (
-              <div key={entry.command} className="relative border-b border-[var(--rule)] px-5 py-5 last:border-b-0 sm:pr-16">
-                <p className="mb-2 font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-                  {String(index + 1).padStart(2, '0')} · {entry.label}
-                </p>
-                <code className="block min-w-0 break-all pr-12 text-[11px] leading-5 text-[var(--foreground)] sm:overflow-x-auto sm:whitespace-nowrap sm:pr-0 sm:text-xs sm:leading-6">
-                  {entry.command}
-                </code>
+              <div
+                key={entry.command}
+                className="flex items-center gap-3 rounded-xl bg-[var(--surface-muted)] py-3 pl-4 pr-2.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="mb-1 text-[11px] font-medium text-[var(--muted)]">
+                    {index + 1}. {entry.label}
+                  </p>
+                  <code className="block min-w-0 overflow-x-auto whitespace-nowrap font-mono text-xs text-[var(--foreground)]">
+                    {entry.command}
+                  </code>
+                </div>
                 <button
                   type="button"
                   onClick={() => copyCommands(copyKey, entry.command, entry.label)}
-                  className={`absolute right-4 top-1/2 grid h-9 w-9 -translate-y-1/2 place-items-center border transition-colors ${
+                  className={`grid h-9 w-9 shrink-0 place-items-center rounded-full transition-all ${
                     isCopied
-                      ? 'border-[var(--accent)] bg-[var(--accent)] text-[var(--background)]'
-                      : 'border-[var(--rule-strong)] bg-[var(--background)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
+                      ? 'bg-[var(--accent)] text-[var(--on-accent)]'
+                      : 'bg-[var(--surface)] text-[var(--muted)] shadow-[var(--shadow-card)] hover:text-[var(--accent)]'
                   }`}
                   aria-label={`Copy ${entry.label} command`}
                 >

--- a/web/src/components/RepositoryInstallPanel.tsx
+++ b/web/src/components/RepositoryInstallPanel.tsx
@@ -91,13 +91,13 @@ export function RepositoryInstallPanel() {
             return (
               <div
                 key={entry.command}
-                className="flex items-center gap-3 rounded-xl bg-[var(--surface-muted)] py-3 pl-4 pr-2.5"
+                className="flex min-w-0 items-center gap-3 rounded-xl bg-[var(--surface-muted)] py-3 pl-4 pr-2.5"
               >
                 <div className="min-w-0 flex-1">
                   <p className="mb-1 text-[11px] font-medium text-[var(--muted)]">
                     {index + 1}. {entry.label}
                   </p>
-                  <code className="block min-w-0 overflow-x-auto whitespace-nowrap font-mono text-xs text-[var(--foreground)]">
+                  <code className="block min-w-0 overflow-x-auto whitespace-nowrap pb-1 font-mono text-xs text-[var(--foreground)] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[var(--border-strong)] [&::-webkit-scrollbar-track]:bg-transparent">
                     {entry.command}
                   </code>
                 </div>

--- a/web/src/components/RepositoryInstallPanel.tsx
+++ b/web/src/components/RepositoryInstallPanel.tsx
@@ -121,29 +121,21 @@ export function RepositoryInstallPanel() {
                   }`}
                   aria-label={`Copy ${entry.label} command`}
                 >
-                  <AnimatePresence mode="wait" initial={false}>
-                    {isCopied ? (
-                      <motion.span
-                        key="copied"
-                        initial={{ scale: 0.4, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0.4, opacity: 0 }}
-                        transition={{ type: 'spring', stiffness: 500, damping: 22 }}
-                      >
-                        <Check size={14} />
-                      </motion.span>
-                    ) : (
-                      <motion.span
-                        key="copy"
-                        initial={{ scale: 0.4, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0.4, opacity: 0 }}
-                        transition={{ type: 'spring', stiffness: 300, damping: 24 }}
-                      >
-                        <Copy size={14} strokeWidth={1.5} />
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
+                  <span className="grid">
+                    <Check
+                      size={14}
+                      className={`col-start-1 row-start-1 place-self-center transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
+                        isCopied ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+                      }`}
+                    />
+                    <Copy
+                      size={14}
+                      strokeWidth={1.5}
+                      className={`col-start-1 row-start-1 place-self-center transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
+                        isCopied ? 'scale-50 opacity-0' : 'scale-100 opacity-100'
+                      }`}
+                    />
+                  </span>
                 </motion.button>
               </div>
             );

--- a/web/src/components/RepositoryInstallPanel.tsx
+++ b/web/src/components/RepositoryInstallPanel.tsx
@@ -97,7 +97,7 @@ export function RepositoryInstallPanel() {
                   <p className="mb-1 text-[11px] font-medium text-[var(--muted)]">
                     {index + 1}. {entry.label}
                   </p>
-                  <code className="block min-w-0 overflow-x-auto whitespace-nowrap pb-1 font-mono text-xs text-[var(--foreground)] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[var(--border-strong)] [&::-webkit-scrollbar-track]:bg-transparent">
+                  <code className="block min-w-0 select-all truncate font-mono text-xs text-[var(--foreground)]" title={entry.command}>
                     {entry.command}
                   </code>
                 </div>

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -66,43 +66,34 @@ export function SkillCard({ skill, position, onClick }: SkillCardProps) {
       ref={cardRef}
       type="button"
       layout
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -8 }}
-      transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0, transition: { type: 'spring', stiffness: 260, damping: 28, delay: Math.min(position, 12) * 0.035 } }}
+      exit={{ opacity: 0, scale: 0.96, transition: { duration: 0.15 } }}
+      transition={{ type: 'spring', stiffness: 320, damping: 30 }}
       onClick={handleClick}
-      className="group relative grid min-h-32 w-full cursor-pointer grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-4 border-b border-[var(--rule)] px-1 py-6 text-left transition-colors hover:bg-[linear-gradient(90deg,color-mix(in_srgb,var(--accent)_7%,transparent),transparent_74%)] sm:grid-cols-[3rem_minmax(0,1fr)_12rem_8rem] sm:gap-6"
+      className="group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 text-left shadow-[var(--shadow-card)] transition-[box-shadow,border-color,transform] duration-200 hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--accent)_32%,var(--border))] hover:shadow-[var(--shadow-card-hover)]"
     >
-      <span className="grid place-items-center" aria-hidden="true">
-        <span className="h-2 w-2 rotate-45 border border-[var(--rule-strong)] transition-all group-hover:border-[var(--accent)] group-hover:shadow-[0_0_14px_color-mix(in_srgb,var(--accent)_72%,transparent)]" />
+      <span className="font-display block text-base font-bold tracking-tight text-[var(--foreground)]">
+        {displayName}
+      </span>
+      <span className="mt-2 line-clamp-2 block text-sm leading-6 text-[var(--muted)]">
+        {displayDescription}
       </span>
 
-      <span className="min-w-0">
-        <span className="font-display block text-xl font-extrabold tracking-[-0.025em] text-[var(--foreground)] sm:text-2xl">
-          {displayName}
+      <span className="mt-auto flex items-center justify-between gap-3 pt-5">
+        <span className="flex min-w-0 items-center gap-3 font-mono text-[11px] text-[var(--muted)]">
+          <span className="flex items-center gap-1.5">
+            <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
+            <span className="truncate">{publishedAt ?? 'Undated'}</span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <Files size={12} strokeWidth={1.5} className="shrink-0" />
+            {skill.fileCount} {skill.fileCount === 1 ? 'file' : 'files'}
+          </span>
         </span>
-        <span className="mt-2 block max-w-3xl text-sm leading-6 text-[var(--muted)]">
-          {displayDescription}
+        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-all duration-200 group-hover:bg-[var(--accent)] group-hover:text-[var(--on-accent)]">
+          <ArrowRight size={14} strokeWidth={2} className="transition-transform duration-200 group-hover:translate-x-px" />
         </span>
-        <span className="mt-3 inline-flex font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--signal)] sm:hidden">
-          {skill.installName}
-        </span>
-      </span>
-
-      <span className="hidden min-w-0 sm:block">
-        <span className="flex items-center gap-2 font-mono text-[10px] text-[var(--muted)]">
-          <CalendarDays size={13} strokeWidth={1.5} />
-          {publishedAt ?? 'Uncalibrated'}
-        </span>
-        <span className="mt-2 flex items-center gap-2 font-mono text-[10px] text-[var(--muted)]">
-          <Files size={13} strokeWidth={1.5} />
-          {skill.fileCount} {skill.fileCount === 1 ? 'file' : 'files'}
-        </span>
-      </span>
-
-      <span className="flex items-center gap-2 justify-self-end text-xs font-semibold uppercase tracking-[0.1em] text-[var(--muted)] transition-colors group-hover:text-[var(--accent)]">
-        <span className="hidden lg:inline">View skill</span>
-        <ArrowRight size={18} strokeWidth={1.5} className="transition-transform group-hover:translate-x-1" />
       </span>
     </motion.button>
   );

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { motion } from 'motion/react';
+import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
 import { ArrowRight, CalendarDays, Files } from 'lucide-react';
 import { trackEvent } from '@/lib/gtag';
 import { formatSkillPublishedAt } from '@/lib/utils';
@@ -16,6 +16,9 @@ interface SkillCardProps {
 export function SkillCard({ skill, position, onClick }: SkillCardProps) {
   const cardRef = useRef<HTMLButtonElement | null>(null);
   const hasTrackedImpression = useRef(false);
+  const spotlightX = useMotionValue(0);
+  const spotlightY = useMotionValue(0);
+  const spotlight = useMotionTemplate`radial-gradient(220px circle at ${spotlightX}px ${spotlightY}px, color-mix(in srgb, var(--accent) 7%, transparent), transparent 72%)`;
   const displayName = skill.metadata?.name ?? skill.name;
   const displayDescription = skill.metadata?.description ?? skill.description;
   const publishedAt = formatSkillPublishedAt(skill.metadata?.created);
@@ -73,9 +76,19 @@ export function SkillCard({ skill, position, onClick }: SkillCardProps) {
       whileHover={{ y: -4 }}
       whileTap={{ scale: 0.98 }}
       onClick={handleClick}
-      className="group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 text-left shadow-[var(--shadow-card)] transition-[box-shadow,border-color] duration-200 hover:border-[color-mix(in_srgb,var(--accent)_32%,var(--border))] hover:shadow-[var(--shadow-card-hover)]"
+      onMouseMove={(event) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        spotlightX.set(event.clientX - rect.left);
+        spotlightY.set(event.clientY - rect.top);
+      }}
+      className="group relative flex h-full w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 text-left shadow-[var(--shadow-card)] transition-[box-shadow,border-color] duration-200 hover:border-[color-mix(in_srgb,var(--accent)_32%,var(--border))] hover:shadow-[var(--shadow-card-hover)] focus-visible:outline-offset-[-3px]"
     >
-      <span className="font-display block text-base font-bold tracking-tight text-[var(--foreground)]">
+      <motion.span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        style={{ background: spotlight }}
+      />
+      <span className="font-display relative block text-base font-bold tracking-tight text-[var(--foreground)] transition-colors duration-200 group-hover:text-[var(--accent)]">
         {displayName}
       </span>
       <span className="mt-2 line-clamp-2 block text-sm leading-6 text-[var(--muted)]">

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -70,8 +70,10 @@ export function SkillCard({ skill, position, onClick }: SkillCardProps) {
       animate={{ opacity: 1, y: 0, transition: { type: 'spring', stiffness: 260, damping: 28, delay: Math.min(position, 12) * 0.035 } }}
       exit={{ opacity: 0, scale: 0.96, transition: { duration: 0.15 } }}
       transition={{ type: 'spring', stiffness: 320, damping: 30 }}
+      whileHover={{ y: -4 }}
+      whileTap={{ scale: 0.98 }}
       onClick={handleClick}
-      className="group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 text-left shadow-[var(--shadow-card)] transition-[box-shadow,border-color,transform] duration-200 hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--accent)_32%,var(--border))] hover:shadow-[var(--shadow-card-hover)]"
+      className="group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 text-left shadow-[var(--shadow-card)] transition-[box-shadow,border-color] duration-200 hover:border-[color-mix(in_srgb,var(--accent)_32%,var(--border))] hover:shadow-[var(--shadow-card-hover)]"
     >
       <span className="font-display block text-base font-bold tracking-tight text-[var(--foreground)]">
         {displayName}

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -263,27 +263,44 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
                         <code className="min-w-0 flex-1 select-all truncate font-mono text-xs text-[var(--foreground)]">
                           {command}
                         </code>
-                        <button
+                        <motion.button
                           onClick={copyToClipboard}
                           type="button"
-                          className={`flex h-9 shrink-0 items-center gap-1.5 rounded-full px-4 text-xs font-semibold transition-all ${
+                          whileTap={{ scale: 0.92 }}
+                          className={`flex h-9 shrink-0 items-center gap-1.5 rounded-full px-4 text-xs font-semibold transition-colors ${
                             copied
                               ? 'bg-[var(--accent)] text-[var(--on-accent)]'
                               : 'bg-[var(--surface)] text-[var(--muted)] shadow-[var(--shadow-card)] hover:text-[var(--accent)]'
                           }`}
                         >
-                          {copied ? (
-                            <>
-                              <Check size={13} />
-                              <span>Copied</span>
-                            </>
-                          ) : (
-                            <>
-                              <Copy size={13} />
-                              <span>Copy</span>
-                            </>
-                          )}
-                        </button>
+                          <AnimatePresence mode="wait" initial={false}>
+                            {copied ? (
+                              <motion.span
+                                key="copied"
+                                className="flex items-center gap-1.5"
+                                initial={{ scale: 0.5, opacity: 0 }}
+                                animate={{ scale: 1, opacity: 1 }}
+                                exit={{ scale: 0.5, opacity: 0 }}
+                                transition={{ type: 'spring', stiffness: 500, damping: 22 }}
+                              >
+                                <Check size={13} />
+                                <span>Copied</span>
+                              </motion.span>
+                            ) : (
+                              <motion.span
+                                key="copy"
+                                className="flex items-center gap-1.5"
+                                initial={{ scale: 0.5, opacity: 0 }}
+                                animate={{ scale: 1, opacity: 1 }}
+                                exit={{ scale: 0.5, opacity: 0 }}
+                                transition={{ type: 'spring', stiffness: 300, damping: 24 }}
+                              >
+                                <Copy size={13} />
+                                <span>Copy</span>
+                              </motion.span>
+                            )}
+                          </AnimatePresence>
+                        </motion.button>
                       </div>
                     </div>
                   ) : null}

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Skill } from '@/lib/skills';
-import { Dialog, Transition } from '@headlessui/react';
-import { Fragment, useState, useEffect, useRef } from 'react';
+import { Dialog } from '@headlessui/react';
+import { useState, useEffect, useRef } from 'react';
+import { AnimatePresence, MotionConfig, motion } from 'motion/react';
 import ReactMarkdown from 'react-markdown';
 import { X, Terminal, Copy, Check, ExternalLink, CalendarDays, Files } from 'lucide-react';
 import { formatSkillPublishedAt } from '@/lib/utils';
@@ -92,8 +93,6 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
     trackedViewSlug.current = skill.slug;
   }, [displayName, isOpen, skill]);
 
-  if (!isOpen) return null;
-
   const command = skill
     ? `npx skills add https://github.com/flc1125/skills --skill ${skill.installName}`
     : '';
@@ -115,60 +114,50 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
   };
 
   return (
-    <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-[rgba(2,7,14,0.74)] backdrop-blur-md" />
-        </Transition.Child>
+    <MotionConfig reducedMotion="user">
+      <AnimatePresence>
+        {isOpen && (
+          <Dialog open={isOpen} onClose={onClose} className="relative z-50">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="fixed inset-0 bg-[rgba(12,14,22,0.45)] backdrop-blur-sm"
+              aria-hidden="true"
+            />
 
-        <div className="fixed inset-0 overflow-y-auto">
-          <div className="flex min-h-full items-center justify-center p-3 sm:p-4">
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
-            >
-              <Dialog.Panel className="w-full max-w-5xl transform overflow-hidden border border-[var(--rule-strong)] border-t-[color-mix(in_srgb,var(--accent)_72%,transparent)] bg-[var(--surface)] p-0 shadow-[var(--shadow-station)] transition-all">
-                <div className="relative h-1 bg-[var(--accent)] after:absolute after:left-0 after:top-0 after:h-2 after:w-2 after:bg-[var(--accent)] after:shadow-[0_0_18px_color-mix(in_srgb,var(--accent)_72%,transparent)]" />
-                <div className="flex items-start justify-between gap-3 border-b border-[var(--rule)] bg-[color-mix(in_srgb,var(--surface-muted)_72%,var(--surface))] px-5 py-5 sm:items-center sm:gap-5 sm:px-7">
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <div className="flex h-11 w-11 shrink-0 items-center justify-center border border-[var(--rule-strong)] bg-[var(--background)] text-[var(--signal)]">
-                        <Terminal size={19} strokeWidth={1.5} />
-                      </div>
-                      <Dialog.Title as="h3" className="font-display min-w-0 text-3xl font-extrabold leading-tight tracking-[-0.04em] text-[var(--foreground)]">
+            <div className="fixed inset-0 overflow-y-auto">
+              <div className="flex min-h-full items-center justify-center p-4 sm:p-6">
+                <motion.div
+                  initial={{ opacity: 0, scale: 0.96, y: 16 }}
+                  animate={{ opacity: 1, scale: 1, y: 0 }}
+                  exit={{ opacity: 0, scale: 0.97, y: 10 }}
+                  transition={{ type: 'spring', stiffness: 320, damping: 30 }}
+                  className="w-full max-w-3xl"
+                >
+                  <Dialog.Panel className="w-full overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-modal)]">
+                  <div className="flex items-start justify-between gap-4 px-6 pt-6 sm:px-8 sm:pt-7">
+                    <div className="min-w-0">
+                      <Dialog.Title as="h3" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
                         {displayName}
                       </Dialog.Title>
-                    </div>
-                    <div className="min-w-0 pl-14">
                       {skill ? (
-                        <div className="mt-2 flex min-w-0 flex-wrap items-center gap-2 font-mono text-[10px] font-semibold text-[var(--muted)]">
-                          <span className="inline-flex h-8 max-w-full items-center border border-[var(--rule)] bg-[var(--background)] px-2.5 lowercase text-[var(--signal)]">
+                        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 text-xs">
+                          <span className="inline-flex h-7 max-w-full items-center rounded-full bg-[var(--surface-muted)] px-3 font-mono text-[11px] text-[var(--muted)]">
                             {skill.name}
                           </span>
                           {publishedAt ? (
-                            <div className="flex h-8 items-center gap-1.5 border border-[var(--rule)] bg-[var(--background)] px-2.5 text-[var(--muted)]">
-                              <CalendarDays size={12} className="flex-shrink-0" />
-                              <span>{publishedAt}</span>
-                            </div>
+                            <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
+                              <CalendarDays size={12} className="shrink-0" />
+                              {publishedAt}
+                            </span>
                           ) : null}
                           {fileCountLabel ? (
-                            <div className="flex h-8 items-center gap-1.5 border border-[var(--rule)] bg-[var(--background)] px-2.5 text-[var(--muted)]">
-                              <Files size={12} className="flex-shrink-0" />
-                              <span>{fileCountLabel}</span>
-                            </div>
+                            <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
+                              <Files size={12} className="shrink-0" />
+                              {fileCountLabel}
+                            </span>
                           ) : null}
                           <a
                             href={sourceUrl}
@@ -181,133 +170,130 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
                                 target: 'github_skill_source',
                               });
                             }}
-                            className="inline-flex h-8 shrink-0 basis-full items-center justify-center gap-1.5 border border-[color-mix(in_srgb,var(--signal)_52%,transparent)] bg-[color-mix(in_srgb,var(--signal)_9%,transparent)] px-2.5 text-[var(--signal)] transition-colors hover:bg-[var(--signal)] hover:text-[var(--background)] sm:basis-auto"
+                            className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--accent-soft)] px-3 font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--on-accent)]"
                             title="View source file on GitHub"
                           >
-                            <ExternalLink size={12} className="flex-shrink-0" />
-                            <span>View on GitHub</span>
+                            <ExternalLink size={12} className="shrink-0" />
+                            View on GitHub
                           </a>
                         </div>
                       ) : null}
                     </div>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
                     <button
                       onClick={onClose}
-                      className="flex h-11 w-11 items-center justify-center border border-[var(--rule-strong)] bg-[var(--background)] text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                      className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
                       aria-label="Close skill details"
                     >
-                      <X size={18} />
+                      <X size={17} />
                     </button>
                   </div>
-                </div>
 
-                <div className="max-h-[62vh] overflow-y-auto px-5 py-6 custom-scrollbar sm:px-7">
-                  {isLoading ? (
-                    <div className="space-y-3 animate-pulse">
-                      <div className="h-4 bg-[var(--surface-muted)]" />
-                      <div className="h-4 bg-[var(--surface-muted)]" />
-                      <div className="h-4 w-5/6 bg-[var(--surface-muted)]" />
-                      <div className="h-24 bg-[var(--background)]" />
-                    </div>
-                  ) : error ? (
-                    <div className="border border-[var(--rule)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)]">
-                      {error}
-                    </div>
-                  ) : skill ? (
-                    <div className="prose max-w-none text-[var(--foreground)] dark:prose-invert
-                      prose-headings:font-display prose-headings:font-extrabold prose-headings:tracking-[-0.04em] prose-headings:text-[var(--foreground)] prose-h1:text-3xl prose-h2:text-2xl
-                      prose-p:max-w-[65ch] prose-p:text-sm prose-p:leading-7 prose-p:text-[var(--muted)] prose-li:text-sm prose-li:leading-7 prose-li:text-[var(--muted)] prose-a:font-semibold prose-a:text-[var(--accent)]">
-                      <ReactMarkdown
-                        components={{
-                          pre({ children }) {
-                            return (
-                              <pre className="my-4 overflow-x-auto border border-[var(--rule-strong)] bg-[var(--background)] p-4 text-xs text-[var(--foreground)]">
-                                {children}
-                              </pre>
-                            )
-                          },
-                          code(props) {
-                            const { children, className, ...codeProps } = props;
-                            const { node: _node, inline: _inline, ...rest } = codeProps as typeof codeProps & {
-                              inline?: boolean;
-                              node?: unknown;
-                            };
-                            const match = /language-(\w+)/.exec(className || '');
-                            return match ? (
-                              <code className={className} {...rest}>
-                                {children}
-                              </code>
-                            ) : (
-                              <code className="mx-0.5 bg-[var(--surface-muted)] px-2 py-0.5 font-semibold text-[var(--foreground)] before:content-none after:content-none" {...rest}>
-                                {children}
-                              </code>
-                            )
-                          },
-                          a({ href, children, ...props }) {
-                            const resolvedHref = skill ? resolveSkillContentLink(skill, href) : href;
-                            const isExternal = resolvedHref?.startsWith('http://') || resolvedHref?.startsWith('https://');
+                  <div className="mt-5 max-h-[58vh] overflow-y-auto px-6 pb-2 custom-scrollbar sm:px-8">
+                    {isLoading ? (
+                      <div className="space-y-3 animate-pulse pb-4">
+                        <div className="h-4 rounded-full bg-[var(--surface-muted)]" />
+                        <div className="h-4 rounded-full bg-[var(--surface-muted)]" />
+                        <div className="h-4 w-5/6 rounded-full bg-[var(--surface-muted)]" />
+                        <div className="h-24 rounded-2xl bg-[var(--surface-muted)]" />
+                      </div>
+                    ) : error ? (
+                      <div className="rounded-2xl bg-[var(--accent-soft)] px-4 py-3 text-sm text-[var(--foreground)]">
+                        {error}
+                      </div>
+                    ) : skill ? (
+                      <div className="prose max-w-none text-[var(--foreground)] dark:prose-invert
+                        prose-headings:font-display prose-headings:font-bold prose-headings:tracking-tight prose-headings:text-[var(--foreground)] prose-h1:text-2xl prose-h2:text-xl
+                        prose-p:max-w-[65ch] prose-p:text-sm prose-p:leading-7 prose-p:text-[var(--muted)] prose-li:text-sm prose-li:leading-7 prose-li:text-[var(--muted)] prose-a:font-semibold prose-a:text-[var(--accent)]">
+                        <ReactMarkdown
+                          components={{
+                            pre({ children }) {
+                              return (
+                                <pre className="my-4 overflow-x-auto rounded-xl bg-[var(--surface-muted)] p-4 text-xs text-[var(--foreground)]">
+                                  {children}
+                                </pre>
+                              )
+                            },
+                            code(props) {
+                              const { children, className, ...codeProps } = props;
+                              const { node: _node, inline: _inline, ...rest } = codeProps as typeof codeProps & {
+                                inline?: boolean;
+                                node?: unknown;
+                              };
+                              const match = /language-(\w+)/.exec(className || '');
+                              return match ? (
+                                <code className={className} {...rest}>
+                                  {children}
+                                </code>
+                              ) : (
+                                <code className="mx-0.5 rounded-md bg-[var(--surface-muted)] px-1.5 py-0.5 font-semibold text-[var(--foreground)] before:content-none after:content-none" {...rest}>
+                                  {children}
+                                </code>
+                              )
+                            },
+                            a({ href, children, ...props }) {
+                              const resolvedHref = skill ? resolveSkillContentLink(skill, href) : href;
+                              const isExternal = resolvedHref?.startsWith('http://') || resolvedHref?.startsWith('https://');
 
-                            return (
-                              <a
-                                href={resolvedHref}
-                                target={isExternal ? '_blank' : undefined}
-                                rel={isExternal ? 'noopener noreferrer' : undefined}
-                                {...props}
-                              >
-                                {children}
-                              </a>
-                            );
-                          }
-                        }}
-                      >
-                        {skill.content}
-                      </ReactMarkdown>
+                              return (
+                                <a
+                                  href={resolvedHref}
+                                  target={isExternal ? '_blank' : undefined}
+                                  rel={isExternal ? 'noopener noreferrer' : undefined}
+                                  {...props}
+                                >
+                                  {children}
+                                </a>
+                              );
+                            }
+                          }}
+                        >
+                          {skill.content}
+                        </ReactMarkdown>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  {skill ? (
+                    <div className="px-6 pb-6 pt-4 sm:px-8 sm:pb-7">
+                      <p className="mb-2 text-xs font-medium text-[var(--muted)]">
+                        Install this skill
+                      </p>
+                      <div className="flex items-center gap-3 rounded-xl bg-[var(--surface-muted)] py-2.5 pl-4 pr-2">
+                        <Terminal size={15} className="shrink-0 text-[var(--accent)]" />
+                        <code className="min-w-0 flex-1 select-all truncate font-mono text-xs text-[var(--foreground)]">
+                          {command}
+                        </code>
+                        <button
+                          onClick={copyToClipboard}
+                          type="button"
+                          className={`flex h-9 shrink-0 items-center gap-1.5 rounded-full px-4 text-xs font-semibold transition-all ${
+                            copied
+                              ? 'bg-[var(--accent)] text-[var(--on-accent)]'
+                              : 'bg-[var(--surface)] text-[var(--muted)] shadow-[var(--shadow-card)] hover:text-[var(--accent)]'
+                          }`}
+                        >
+                          {copied ? (
+                            <>
+                              <Check size={13} />
+                              <span>Copied</span>
+                            </>
+                          ) : (
+                            <>
+                              <Copy size={13} />
+                              <span>Copy</span>
+                            </>
+                          )}
+                        </button>
+                      </div>
                     </div>
                   ) : null}
-                </div>
-
-                {skill ? (
-                  <div className="border-t border-[var(--rule)] bg-[color-mix(in_srgb,var(--surface-muted)_72%,var(--surface))] px-5 py-5 sm:px-7">
-                  <p className="mb-2.5 ml-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-                    Install this individual skill
-                  </p>
-                  <div className="group">
-                    <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border border-[var(--rule-strong)] bg-[var(--background)] px-4 py-3 transition-colors group-hover:border-[var(--accent)]">
-                      <Terminal size={16} className="flex-shrink-0 text-[var(--signal)]" />
-                      <code className="min-w-0 flex-1 select-all truncate font-mono text-xs text-[var(--foreground)]">
-                        {command}
-                      </code>
-                      <button
-                        onClick={copyToClipboard}
-                        type="button"
-                        className={`flex min-h-11 items-center gap-1.5 px-4 font-bold text-xs leading-none transition-all ${
-                          copied 
-                            ? 'bg-[var(--accent)] text-white scale-95'
-                            : 'border border-[var(--rule-strong)] bg-[var(--surface)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] active:scale-95'
-                        }`}
-                      >
-                        {copied ? (
-                          <>
-                            <Check size={14} />
-                            <span>Copied</span>
-                          </>
-                        ) : (
-                          <>
-                            <Copy size={14} />
-                            <span>Copy</span>
-                          </>
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                  </div>
-                ) : null}
-              </Dialog.Panel>
-            </Transition.Child>
-          </div>
-        </div>
-      </Dialog>
-    </Transition>
+                  </Dialog.Panel>
+                </motion.div>
+              </div>
+            </div>
+          </Dialog>
+        )}
+      </AnimatePresence>
+    </MotionConfig>
   );
 }

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -273,33 +273,24 @@ export function SkillModal({ skill, isOpen, isLoading, error, onClose }: SkillMo
                               : 'bg-[var(--surface)] text-[var(--muted)] shadow-[var(--shadow-card)] hover:text-[var(--accent)]'
                           }`}
                         >
-                          <AnimatePresence mode="wait" initial={false}>
-                            {copied ? (
-                              <motion.span
-                                key="copied"
-                                className="flex items-center gap-1.5"
-                                initial={{ scale: 0.5, opacity: 0 }}
-                                animate={{ scale: 1, opacity: 1 }}
-                                exit={{ scale: 0.5, opacity: 0 }}
-                                transition={{ type: 'spring', stiffness: 500, damping: 22 }}
-                              >
-                                <Check size={13} />
-                                <span>Copied</span>
-                              </motion.span>
-                            ) : (
-                              <motion.span
-                                key="copy"
-                                className="flex items-center gap-1.5"
-                                initial={{ scale: 0.5, opacity: 0 }}
-                                animate={{ scale: 1, opacity: 1 }}
-                                exit={{ scale: 0.5, opacity: 0 }}
-                                transition={{ type: 'spring', stiffness: 300, damping: 24 }}
-                              >
-                                <Copy size={13} />
-                                <span>Copy</span>
-                              </motion.span>
-                            )}
-                          </AnimatePresence>
+                          <span className="grid">
+                            <span
+                              className={`col-start-1 row-start-1 flex items-center justify-center gap-1.5 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
+                                copied ? 'scale-100 opacity-100' : 'scale-75 opacity-0'
+                              }`}
+                            >
+                              <Check size={13} />
+                              <span>Copied</span>
+                            </span>
+                            <span
+                              className={`col-start-1 row-start-1 flex items-center justify-center gap-1.5 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
+                                copied ? 'scale-75 opacity-0' : 'scale-100 opacity-100'
+                              }`}
+                            >
+                              <Copy size={13} />
+                              <span>Copy</span>
+                            </span>
+                          </span>
                         </motion.button>
                       </div>
                     </div>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -90,25 +90,25 @@ export function ThemeToggle() {
   };
 
   return (
-    <Menu as="div" className="relative h-full w-full">
+    <Menu as="div" className="relative">
       <Menu.Button
         aria-label={`Theme selector, current theme: ${activeOption.label}`}
         title={`Theme: ${activeOption.label}`}
-        className="grid h-full w-full place-items-center text-[var(--muted)] transition-colors hover:bg-[color-mix(in_srgb,var(--surface-muted)_48%,transparent)] hover:text-[var(--foreground)]"
+        className="grid h-9 w-9 place-items-center rounded-full text-[var(--muted)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--foreground)]"
       >
-        <ActiveIcon size={15} />
+        <ActiveIcon size={16} />
       </Menu.Button>
 
       <Transition
         as={Fragment}
         enter="transition ease-out duration-150"
-        enterFrom="opacity-0 -translate-y-1"
-        enterTo="opacity-100 translate-y-0"
+        enterFrom="opacity-0 -translate-y-1 scale-95"
+        enterTo="opacity-100 translate-y-0 scale-100"
         leave="transition ease-in duration-100"
-        leaveFrom="opacity-100 translate-y-0"
-        leaveTo="opacity-0 -translate-y-1"
+        leaveFrom="opacity-100 translate-y-0 scale-100"
+        leaveTo="opacity-0 -translate-y-1 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-1.5 w-38 origin-top-right border border-[var(--rule-strong)] bg-[var(--surface)] p-1 shadow-[var(--shadow-station)] backdrop-blur-md focus:outline-none">
+        <Menu.Items className="absolute right-0 mt-2 w-40 origin-top-right rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-1.5 shadow-[var(--shadow-card-hover)] focus:outline-none">
           {OPTIONS.map((option) => {
             const Icon = option.icon;
             const isActive = option.value === theme;
@@ -119,18 +119,18 @@ export function ThemeToggle() {
                   <button
                     type="button"
                     onClick={() => handleThemeChange(option.value)}
-                    className={`flex min-h-10 w-full items-center justify-between px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.04em] transition-colors ${
+                    className={`flex min-h-10 w-full items-center justify-between rounded-xl px-3 py-2 text-[13px] font-medium transition-colors ${
                       active
-                        ? 'bg-[var(--surface-muted)] text-[var(--accent)]'
+                        ? 'bg-[var(--accent-soft)] text-[var(--accent)]'
                         : 'text-[var(--muted)]'
                     }`}
                   >
-                    <span className="flex items-center gap-2 text-[11px]">
-                      <Icon size={14} />
+                    <span className="flex items-center gap-2.5">
+                      <Icon size={15} />
                       <span>{option.label}</span>
                     </span>
                     <span className="w-4">
-                      {isActive ? <Check size={12} /> : null}
+                      {isActive ? <Check size={13} /> : null}
                     </span>
                   </button>
                 )}


### PR DESCRIPTION
## Summary

Complete visual redesign of the skills marketplace ([skills.flc.io](https://skills.flc.io)), retiring the "Technical Atlas" language in favor of a new **Soft Modern** system:

- Warm off-white canvas, rounded cards, diffused shadows, and a single **vivid tangerine** accent (deliberately avoiding the generic AI-indigo look)
- New typography: Plus Jakarta Sans for display, Inter for UI, loaded via `next/font`
- Catalog switched from horizontal record rows to a responsive card grid (1/2/3 columns)
- New brand mark and favicon: white FS monogram on a rounded tangerine-gradient tile
- `web/DESIGN.md` rewritten to document the new system (tokens, layout, components, motion, anti-patterns)

## Interaction & Motion

- Choreographed hero entrance sequence (fade-up, ~70ms stagger) and count-up stat numbers
- Spring press feedback (`whileTap`) on cards, tabs, and copy buttons
- Copy success feedback: in-place crossfade + scale pop with a slight backOut overshoot (no exit-then-enter dead gap)
- Install provider tabs: sliding indicator (`layoutId`) plus a cross-sliding command area
- Cursor-following spotlight on cards (7% alpha accent wash, driven by Motion values — no React re-renders on mousemove)
- Card hover: lift, accent-tinted title, border and shadow transitions
- Search pill scales slightly on focus; empty state icon springs in with a wobble
- Global 200ms color transitions make theme switching smooth
- **Quick install panel collapses while searching**, so results sit directly beneath the search field instead of a full viewport away
- All motion respects `prefers-reduced-motion`

## Functionality — unchanged

- Skills data pipeline (`generate-skills-data.mjs` → `data/skills.json` → `lib/skills.ts`) untouched; `lib/` and the API route are unmodified
- Search by name/description, newest-first ordering, `⌘K` focus, `?skill=<slug>` URL behavior, and modal fetch through `/api/skills/[slug]` all preserved
- All Google Analytics event names and payloads preserved (`skill_search`, `skill_list_impression`, `skill_card_click`, `skill_detail_view`, `skill_install_copy`, `skill_source_click`, `repository_install_copy`, `nav_github_click`)
- Repository and individual skill install copy behavior, GitHub source links, and relative Markdown link resolution preserved
- Theme switching (system/light/dark) with the no-flash inline script
- Loading, empty, and invalid-slug states; responsive without horizontal overflow

## Fixes included

- `:focus-visible` outline moved into `@layer base` so Tailwind's `outline-none` can override it (previously a stray 2px outline appeared inside the search pill)
- Mobile overflow in Quick install command rows (grid item `min-width: auto` propagated the full command width); commands now truncate with an ellipsis like the modal
- Brand mark letter spacing — the F and S overlapped and were illegible

## Validation

- `npm run build` passes (Turbopack + TypeScript checks)
- Production server smoke tests: home 200, `/api/skills/code-review` 200, invalid slug 404
- Headless Chrome verification at 390px (no horizontal overflow, command truncation, panel collapse while searching) and 1280px (card spotlight hover, search focus state)
- Note: `npm run lint` is broken on `main` as well (ESLint 10 vs `eslint-plugin-react` incompatibility in `eslint-config-next`) — pre-existing, not caused by this PR