### PR TITLE
feat(web): add floating back-to-top button with scroll progress ring

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -84,6 +84,7 @@ The only decorative treatment is a faint tangerine radial glow at the top center
 - Modal: backdrop fade (200ms), panel spring from `scale 0.96 / y 16`. The modal receives the card's display name as `fallbackName` so the real title shows even before the fetch resolves.
 - The header starts borderless/translucent and gains its border + a faint shadow (`--shadow-header`, lighter than card shadows) once the page is scrolled (>8px), over a 300ms transition.
 - The theme toggle icon spins in with a spring (rotate + scale) whenever the theme changes.
+- A floating back-to-top button (accent circle, bottom-right, safe-area aware) appears once half of the first screen has scrolled past (`scrollY > innerHeight * 0.5`, consistent across display sizes), springing in/out; its outer ring fills with scroll progress via `stroke-dashoffset`, doubling as a silent position indicator. Scrolling back to top respects `prefers-reduced-motion`.
 - Inside the modal, loading skeleton / error / markdown content swap through a quick `AnimatePresence mode="wait"` fade (150–200ms) rather than a hard cut.
 - Respect `prefers-reduced-motion` everywhere (`MotionConfig reducedMotion="user"` plus the global CSS guard).
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Script from 'next/script';
 import { Inter, Plus_Jakarta_Sans } from 'next/font/google';
 import { GaPageViewTracker } from '@/components/GaPageViewTracker';
+import { BackToTop } from '@/components/BackToTop';
 import { GithubNavLink } from '@/components/GithubNavLink';
 import { HeaderShell } from '@/components/HeaderShell';
 import { ThemeToggle } from '@/components/ThemeToggle';
@@ -112,6 +113,7 @@ export default function RootLayout({
           </div>
         </HeaderShell>
         <main className="pt-16">{children}</main>
+        <BackToTop />
         <footer className="mt-12 border-t border-[var(--border)] py-10">
           <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-5 text-center sm:px-8">
             <p className="font-display text-sm font-bold text-[var(--foreground)]">Flc&apos;s Skills</p>

--- a/web/src/components/BackToTop.tsx
+++ b/web/src/components/BackToTop.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AnimatePresence, MotionConfig, motion } from 'motion/react';
+import { ArrowUp } from 'lucide-react';
+
+const RING_RADIUS = 21;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+export function BackToTop() {
+  const [visible, setVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const update = () => {
+      const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+
+      // Show once half of the first screen has scrolled past — early
+      // enough to feel responsive, late enough to avoid flashing on
+      // tiny scrolls. Viewport-relative, consistent on any display.
+      setVisible(window.scrollY > window.innerHeight * 0.5);
+      setProgress(maxScroll > 0 ? Math.min(1, window.scrollY / maxScroll) : 0);
+      ticking = false;
+    };
+
+    const handleScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        window.requestAnimationFrame(update);
+      }
+    };
+
+    update();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+  };
+
+  return (
+    <MotionConfig reducedMotion="user">
+      <AnimatePresence>
+        {visible && (
+          <motion.button
+            key="back-to-top"
+            type="button"
+            initial={{ opacity: 0, scale: 0.6, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.6, y: 16 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 26 }}
+            whileTap={{ scale: 0.88 }}
+            onClick={scrollToTop}
+            className="fixed right-5 z-40 grid h-12 w-12 place-items-center rounded-full bg-[var(--accent)] text-[var(--on-accent)] shadow-[var(--shadow-card-hover)] sm:right-6"
+            style={{ bottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
+            aria-label="Back to top"
+          >
+            <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 48 48" aria-hidden="true">
+              <circle
+                cx="24"
+                cy="24"
+                r={RING_RADIUS}
+                fill="none"
+                stroke="var(--on-accent)"
+                strokeOpacity="0.35"
+                strokeWidth="2.5"
+              />
+              <circle
+                cx="24"
+                cy="24"
+                r={RING_RADIUS}
+                fill="none"
+                stroke="var(--on-accent)"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeDasharray={RING_CIRCUMFERENCE}
+                strokeDashoffset={RING_CIRCUMFERENCE * (1 - progress)}
+              />
+            </svg>
+            <ArrowUp size={18} />
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </MotionConfig>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a floating back-to-top button to the marketplace page, matching the accent-circle style already used inside the skill modal.

## Behavior

- **Trigger**: the button springs in once half of the first screen has scrolled past (`scrollY > window.innerHeight * 0.5`) and springs out when scrolling back above it. The viewport-relative threshold keeps the trigger consistent across laptop, desktop, and mobile displays (an earlier fixed-pixel threshold would have felt early on large monitors and late on small ones)
- **Scroll progress ring**: an outer SVG ring fills via `stroke-dashoffset` as the user scrolls, doubling as a silent position indicator
- **Action**: smooth-scrolls to top; respects `prefers-reduced-motion` by jumping instantly (checked in JS since the CSS guard cannot intercept programmatic `scrollTo`)
- **Mobile**: positioned with `env(safe-area-inset-bottom)` so it clears the home indicator; scroll updates are rAF-throttled
- Motion config: `MotionConfig reducedMotion="user"`, spring entrance/exit, `whileTap` press feedback

## Validation

- `npm run build` passes (Turbopack + TypeScript)
- Headless Chrome checks: hidden at top, exact trigger boundary at `innerHeight * 0.5` (hidden at 400px / visible at 410px on an 813px viewport), progress ring offset matches actual scroll ratio, click invokes `scrollTo({ top: 0, behavior: 'smooth' })`
- `DESIGN.md` updated with the component's motion notes