### PR TITLE
fix(web): follow OS theme changes in auto mode without refresh

### DIFF
--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -46,6 +46,19 @@ function applyTheme(mode: ThemeMode) {
   root.style.colorScheme = resolvedTheme;
 }
 
+// The snapshot must change whenever the *resolved* appearance can change,
+// otherwise React bails out of re-rendering and the effect applying the theme
+// never re-runs. In non-system modes the system theme is irrelevant, so the
+// resolved part stays empty and system changes leave the snapshot untouched.
+function getThemeSnapshot(): string {
+  const mode = getStoredTheme();
+  return mode === 'system' ? `${mode}:${getSystemTheme()}` : mode;
+}
+
+function getServerThemeSnapshot(): string {
+  return 'system:light';
+}
+
 const subscribers = new Set<() => void>();
 let mediaQuery: MediaQueryList | null = null;
 
@@ -59,11 +72,7 @@ function ensureMediaQuerySubscription() {
   }
 
   mediaQuery = window.matchMedia(MEDIA_QUERY);
-  mediaQuery.addEventListener('change', () => {
-    if (getStoredTheme() === 'system') {
-      emitThemeChange();
-    }
-  });
+  mediaQuery.addEventListener('change', emitThemeChange);
 }
 
 function subscribe(callback: () => void) {
@@ -76,13 +85,17 @@ function subscribe(callback: () => void) {
 }
 
 export function ThemeToggle() {
-  const theme = useSyncExternalStore(subscribe, getStoredTheme, (): ThemeMode => 'system');
+  const themeSnapshot = useSyncExternalStore(subscribe, getThemeSnapshot, getServerThemeSnapshot);
+  const theme = themeSnapshot.split(':')[0] as ThemeMode;
   const activeOption = OPTIONS.find((option) => option.value === theme) ?? OPTIONS[0];
   const ActiveIcon = activeOption.icon;
 
   useEffect(() => {
     applyTheme(theme);
-  }, [theme]);
+    // themeSnapshot is the real dependency: in system mode it changes when the
+    // OS theme flips even though `theme` stays 'system', and the effect must
+    // re-run to re-apply the resolved appearance.
+  }, [theme, themeSnapshot]);
 
   const handleThemeChange = (mode: ThemeMode) => {
     localStorage.setItem(STORAGE_KEY, mode);


### PR DESCRIPTION
## What

Fixes the auto (system) theme mode not reacting to OS light/dark changes until a page refresh.

## Root cause

`ThemeToggle` used the **stored mode** (`'system' | 'light' | 'dark'`) as the `useSyncExternalStore` snapshot. When the OS theme flipped in auto mode, the media query listener did fire and notified subscribers — but `getSnapshot()` still returned `'system'`, React bailed out of re-rendering, and the `applyTheme` effect never re-ran. Only the inline bootstrap script in `layout.tsx` (which runs once per page load) resolved the theme, hence the refresh requirement.

## Change

- The snapshot now includes the resolved theme in auto mode (e.g. `'system:dark'`), so OS changes produce a new snapshot → re-render → effect re-applies the theme immediately.
- Non-auto modes keep a plain snapshot (`'light'` / `'dark'`), so OS changes cause no re-render there.
- The media query listener now emits unconditionally; snapshot comparison filters irrelevant changes.
- Server snapshot updated to `'system:light'` to match the new format (hydration behavior unchanged).

All changes are contained in `web/src/components/ThemeToggle.tsx`.

## Validation

- `cd web && npm run lint` ✅
- `cd web && npm run build` ✅

## Manual verification

With the theme set to **Auto**, toggle macOS appearance (or DevTools → Rendering → emulate `prefers-color-scheme`) — the page now switches instantly without a refresh.