### PR TITLE
refactor(plugin)!: namespace plugin identifiers under Flc

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,11 +1,11 @@
 {
-  "name": "flc-skills",
+  "name": "flc1125-skills",
   "interface": {
     "displayName": "Flc's Skills"
   },
   "plugins": [
     {
-      "name": "skills",
+      "name": "flc-skills",
       "source": {
         "source": "url",
         "url": "./"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "flc-skills",
+  "name": "flc1125-skills",
   "description": "Flc's curated collection of reusable agent skills, also browsable at https://skills.flc.io",
   "owner": {
     "name": "Flc",
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "skills",
+      "name": "flc-skills",
       "source": "./",
       "description": "A curated collection of reusable agent skills for engineering, research, and knowledge workflows.",
       "category": "Productivity"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "skills",
+  "name": "flc-skills",
   "description": "A curated collection of reusable agent skills maintained by Flc.",
   "author": {
     "name": "Flc",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "skills",
+  "name": "flc-skills",
   "version": "0.6.0",
   "description": "A curated collection of reusable Codex skills maintained by Flc.",
   "author": {

--- a/README.md
+++ b/README.md
@@ -33,25 +33,25 @@ The installable skill content lives in `skills/`. The Next.js marketplace that p
 
 ### Install as a Codex plugin
 
-Add this repository as a Codex plugin marketplace, then install the bundled `skills` plugin:
+Add this repository as a Codex plugin marketplace, then install the bundled `flc-skills` plugin:
 
 ```bash
 codex plugin marketplace add flc1125/skills
-codex plugin add skills@flc-skills
+codex plugin add flc-skills@flc1125-skills
 ```
 
 Use this path when you want the full collection available in Codex.
 
 ### Install as a Claude Code plugin
 
-Add this repository as a Claude Code plugin marketplace, then install the bundled `skills` plugin:
+Add this repository as a Claude Code plugin marketplace, then install the bundled `flc-skills` plugin:
 
 ```bash
 claude plugin marketplace add flc1125/skills
-claude plugin install skills@flc-skills
+claude plugin install flc-skills@flc1125-skills
 ```
 
-Or use the interactive `/plugin` command inside Claude Code. Plugin skills are namespaced, so invoke them as `/skills:<skill-name>` (for example `/skills:code-review`).
+Or use the interactive `/plugin` command inside Claude Code. Plugin skills are namespaced, so invoke them as `/flc-skills:<skill-name>` (for example `/flc-skills:code-review`).
 
 Use this path when you want the full collection available in Claude Code.
 

--- a/web/src/lib/install-methods.ts
+++ b/web/src/lib/install-methods.ts
@@ -26,7 +26,7 @@ export const repositoryInstallMethods: InstallMethod[] = [
       },
       {
         label: 'Install plugin',
-        command: 'codex plugin add skills@flc-skills',
+        command: 'codex plugin add flc-skills@flc1125-skills',
       },
     ],
   },
@@ -43,7 +43,7 @@ export const repositoryInstallMethods: InstallMethod[] = [
       },
       {
         label: 'Install plugin',
-        command: 'claude plugin install skills@flc-skills',
+        command: 'claude plugin install flc-skills@flc1125-skills',
       },
     ],
   },


### PR DESCRIPTION
## Summary
Rename the bundled plugin and its marketplaces to use distinct Flc and GitHub account namespaces. This gives Claude Code a branded skill prefix and leaves room for additional plugin repositories under `flc1125`.

## Changes
- Rename the Codex and Claude Code plugin from `skills` to `flc-skills`
- Rename the repository marketplace from `flc-skills` to `flc1125-skills`
- Update README and web quick-install commands to use the new plugin ID
- Update the Claude Code invocation prefix to `/flc-skills:<skill-name>`

## Motivation
- Make the installed plugin and skill namespace clearly attributable to Flc
- Avoid marketplace naming conflicts as `flc1125` publishes additional plugin repositories

## Breaking Changes
- The plugin ID changes from `skills@flc-skills` to `flc-skills@flc1125-skills`
- The Claude Code skill prefix changes from `/skills:` to `/flc-skills:`
- Existing installations are not renamed automatically

## Before and After

| Surface | Before | After |
| --- | --- | --- |
| Marketplace | `flc-skills` | `flc1125-skills` |
| Plugin | `skills` | `flc-skills` |
| Plugin ID | `skills@flc-skills` | `flc-skills@flc1125-skills` |
| Claude Code prefix | `/skills:<skill-name>` | `/flc-skills:<skill-name>` |

## Migration

1. Remove the old plugin and marketplace:

   ```bash
   # Codex
   codex plugin remove skills@flc-skills
   codex plugin marketplace remove flc-skills

   # Claude Code
   claude plugin uninstall skills@flc-skills
   claude plugin marketplace remove flc-skills
   ```

2. Add the renamed marketplace and install the renamed plugin:

   ```bash
   # Codex
   codex plugin marketplace add flc1125/skills
   codex plugin add flc-skills@flc1125-skills

   # Claude Code
   claude plugin marketplace add flc1125/skills
   claude plugin install flc-skills@flc1125-skills
   ```

3. Update explicit Claude Code skill invocations from `/skills:<skill-name>` to `/flc-skills:<skill-name>`.

## Behavior and Compatibility
- Individual skill install names and `SKILL.md` frontmatter remain unchanged
- The public display name remains unchanged

## Testing
- `claude plugin validate .` passed with the existing missing-version warning
- `npm run lint`
- `npm run build`
- JSON identifier consistency checks
- `git diff --check`