### PR TITLE
feat(web): refine marketplace statistics layout

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,5 @@
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# Local development only: show fake view/copy counts when Upstash is not configured
+SKILL_STATS_MOCK=false

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,3 +3,4 @@ data/skills.json
 public/.well-known/agent-skills/
 node_modules/
 tsconfig.tsbuildinfo
+.env*.local

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -9,7 +9,7 @@ import { RepositoryInstallPanel } from './RepositoryInstallPanel';
 import { SkillCard } from './SkillCard';
 import { SkillModal } from './SkillModal';
 import { trackEvent } from '@/lib/gtag';
-import { parseSkillMetadataDate } from '@/lib/utils';
+import { formatInteractionCount, parseSkillMetadataDate } from '@/lib/utils';
 import type { Skill, SkillMetadata } from '@/lib/skills';
 import type { SkillStats, SkillStatsSnapshot } from '@/lib/skill-stats';
 
@@ -39,10 +39,20 @@ const heroItem: Variants = {
   show: { opacity: 1, y: 0, transition: { type: 'spring', stiffness: 240, damping: 26 } },
 };
 
-function AnimatedNumber({ value }: { value: number }) {
+const defaultNumberFormat = (value: number) => value.toString();
+
+function AnimatedNumber({
+  value,
+  format = defaultNumberFormat,
+}: {
+  value: number;
+  format?: (value: number) => string;
+}) {
   const shouldReduceMotion = useReducedMotion();
   const motionValue = useMotionValue(0);
-  const rounded = useTransform(motionValue, (latest) => Math.round(latest));
+  const rounded = useTransform(motionValue, (latest) =>
+    format(Math.round(latest))
+  );
 
   useEffect(() => {
     const controls = animate(motionValue, value, {
@@ -168,6 +178,19 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
     () => initialSkills.reduce((sum, skill) => sum + skill.fileCount, 0),
     [initialSkills]
   );
+  const totalInteractions = useMemo(() => {
+    if (!statsSnapshot.enabled) {
+      return null;
+    }
+
+    return Object.values(statsSnapshot.skills).reduce(
+      (totals, stats) => ({
+        views: totals.views + stats.views,
+        copies: totals.copies + stats.copies,
+      }),
+      { views: 0, copies: 0 }
+    );
+  }, [statsSnapshot]);
 
   useEffect(() => {
     const query = search.trim();
@@ -270,15 +293,28 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
         </motion.div>
 
         <motion.div variants={heroItem} className="mt-6 flex flex-wrap items-center justify-center gap-2" aria-label="Collection facts">
-          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
-            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]"><AnimatedNumber value={totalSkills} /></strong> skills
+          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium leading-none text-[var(--muted)]">
+            <strong className="mr-1.5 font-display font-bold leading-none text-[var(--foreground)]"><AnimatedNumber value={totalSkills} /></strong> skills
           </span>
-          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
-            <strong className="mr-1.5 font-display font-bold text-[var(--foreground)]"><AnimatedNumber value={totalFiles} /></strong> source files
+          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium leading-none text-[var(--muted)]">
+            <strong className="mr-1.5 font-display font-bold leading-none text-[var(--foreground)]"><AnimatedNumber value={totalFiles} /></strong> files
           </span>
-          <span className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium text-[var(--muted)]">
-            One command to install
-          </span>
+          {totalInteractions ? (
+            <>
+              <span
+                className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium leading-none text-[var(--muted)]"
+                title={`${totalInteractions.views.toLocaleString('en')} views`}
+              >
+                <strong className="mr-1.5 font-display font-bold leading-none text-[var(--foreground)]"><AnimatedNumber value={totalInteractions.views} format={formatInteractionCount} /></strong> views
+              </span>
+              <span
+                className="inline-flex h-8 items-center rounded-full bg-[var(--surface-muted)] px-3.5 text-xs font-medium leading-none text-[var(--muted)]"
+                title={`${totalInteractions.copies.toLocaleString('en')} copies`}
+              >
+                <strong className="mr-1.5 font-display font-bold leading-none text-[var(--foreground)]"><AnimatedNumber value={totalInteractions.copies} format={formatInteractionCount} /></strong> copies
+              </span>
+            </>
+          ) : null}
         </motion.div>
       </section>
 

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
-import { ArrowRight, CalendarDays, Copy, Eye, Files } from 'lucide-react';
+import { ArrowRight, CalendarDays, Copy, Eye } from 'lucide-react';
 import { trackEvent } from '@/lib/gtag';
 import { formatInteractionCount, formatSkillPublishedAt } from '@/lib/utils';
 import type { SkillMetadata } from '@/lib/skills';
@@ -98,31 +98,26 @@ export function SkillCard({ skill, stats, position, onClick }: SkillCardProps) {
         {displayDescription}
       </span>
 
-      {stats ? (
-        <span className="mt-4 flex items-center gap-3 font-mono text-[11px] text-[var(--muted)]">
-          <span className="flex items-center gap-1.5" title={`${stats.views} views`}>
-            <Eye size={12} strokeWidth={1.6} aria-hidden="true" />
-            <span>{formatInteractionCount(stats.views)}</span>
-            <span className="sr-only">views</span>
-          </span>
-          <span className="flex items-center gap-1.5" title={`${stats.copies} copies`}>
-            <Copy size={12} strokeWidth={1.6} aria-hidden="true" />
-            <span>{formatInteractionCount(stats.copies)}</span>
-            <span className="sr-only">copies</span>
-          </span>
-        </span>
-      ) : null}
-
       <span className="mt-auto flex items-center justify-between gap-3 pt-5">
-        <span className="flex min-w-0 items-center gap-3 font-mono text-[11px] text-[var(--muted)]">
+        <span className="flex min-w-0 items-center gap-2.5 font-mono text-[11px] text-[var(--muted)]">
           <span className="flex items-center gap-1.5">
             <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
             <span className="truncate">{publishedAt ?? 'Undated'}</span>
           </span>
-          <span className="flex items-center gap-1.5">
-            <Files size={12} strokeWidth={1.5} className="shrink-0" />
-            {skill.fileCount} {skill.fileCount === 1 ? 'file' : 'files'}
-          </span>
+          {stats ? (
+            <>
+              <span className="flex shrink-0 items-center gap-1.5" title={`${stats.views} views`}>
+                <Eye size={12} strokeWidth={1.6} className="shrink-0" aria-hidden="true" />
+                <span>{formatInteractionCount(stats.views)}</span>
+                <span className="sr-only">views</span>
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5" title={`${stats.copies} copies`}>
+                <Copy size={12} strokeWidth={1.6} className="shrink-0" aria-hidden="true" />
+                <span>{formatInteractionCount(stats.copies)}</span>
+                <span className="sr-only">copies</span>
+              </span>
+            </>
+          ) : null}
         </span>
         <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-all duration-200 group-hover:bg-[var(--accent)] group-hover:text-[var(--on-accent)]">
           <ArrowRight size={14} strokeWidth={2} className="transition-transform duration-200 group-hover:translate-x-px" />

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -99,7 +99,7 @@ export function SkillCard({ skill, stats, position, onClick }: SkillCardProps) {
       </span>
 
       <span className="mt-auto flex items-center justify-between gap-3 pt-5">
-        <span className="flex min-w-0 items-center gap-2.5 font-mono text-[11px] text-[var(--muted)]">
+        <span className="flex min-w-0 items-center gap-2.5 font-mono text-xs text-[var(--muted)]">
           <span className="flex items-center gap-1.5">
             <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
             <span className="truncate">{publishedAt ?? 'Undated'}</span>

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -190,81 +190,81 @@ export function SkillModal({
                   className="w-full max-w-3xl"
                 >
                   <Dialog.Panel className="flex max-h-[calc(100vh-2rem)] max-h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-modal)]">
-                  <div className="flex shrink-0 items-start justify-between gap-4 px-6 pt-6 sm:px-8 sm:pt-7">
-                    <div className="min-w-0">
-                      <Dialog.Title as="h3" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
+                  <div className="shrink-0 px-6 pt-6 sm:px-8 sm:pt-7">
+                    <div className="flex items-start justify-between gap-4">
+                      <Dialog.Title as="h3" className="min-w-0 font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
                         {displayName}
                       </Dialog.Title>
-                      {skill ? (
-                        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 font-mono text-xs">
-                          <span className="inline-flex h-7 max-w-full items-center rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
-                            {skill.name}
-                          </span>
-                          {publishedAt ? (
-                            <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
-                              <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
-                              {publishedAt}
-                            </span>
-                          ) : null}
-                          {fileCountLabel || stats ? (
-                            <span className="inline-flex h-7 items-center gap-2.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
-                              {fileCountLabel ? (
-                                <span className="flex items-center gap-1.5">
-                                  <Files size={12} strokeWidth={1.5} className="shrink-0" />
-                                  {fileCountLabel}
-                                </span>
-                              ) : null}
-                              {stats ? (
-                                <>
-                                  <span
-                                    className="flex items-center gap-1.5"
-                                    title={`${stats.views.toLocaleString('en')} views`}
-                                  >
-                                    <Eye size={12} strokeWidth={1.6} className="shrink-0" />
-                                    {formatInteractionCount(stats.views)} views
-                                  </span>
-                                  <span
-                                    className="flex items-center gap-1.5"
-                                    title={`${stats.copies.toLocaleString('en')} copies`}
-                                  >
-                                    <Copy size={12} strokeWidth={1.6} className="shrink-0" />
-                                    {formatInteractionCount(stats.copies)} copies
-                                  </span>
-                                </>
-                              ) : null}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      {skill ? (
-                        <a
-                          href={sourceUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={() => {
-                            trackEvent('skill_source_click', {
-                              skill_slug: skill.slug,
-                              skill_name: displayName,
-                              target: 'github_skill_source',
-                            });
-                          }}
-                          className="grid h-9 w-9 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
-                          aria-label="View source on GitHub"
-                          title="View source on GitHub"
+                      <div className="flex shrink-0 items-center gap-2">
+                        {skill ? (
+                          <a
+                            href={sourceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => {
+                              trackEvent('skill_source_click', {
+                                skill_slug: skill.slug,
+                                skill_name: displayName,
+                                target: 'github_skill_source',
+                              });
+                            }}
+                            className="grid h-9 w-9 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
+                            aria-label="View source on GitHub"
+                            title="View source on GitHub"
+                          >
+                            <ExternalLink size={16} strokeWidth={1.8} />
+                          </a>
+                        ) : null}
+                        <button
+                          onClick={onClose}
+                          className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
+                          aria-label="Close skill details"
                         >
-                          <ExternalLink size={16} strokeWidth={1.8} />
-                        </a>
-                      ) : null}
-                      <button
-                        onClick={onClose}
-                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
-                        aria-label="Close skill details"
-                      >
-                        <X size={17} />
-                      </button>
+                          <X size={17} />
+                        </button>
+                      </div>
                     </div>
+                    {skill ? (
+                      <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 font-mono text-xs">
+                        <span className="inline-flex h-7 max-w-full items-center rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
+                          {skill.name}
+                        </span>
+                        {publishedAt ? (
+                          <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
+                            <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
+                            {publishedAt}
+                          </span>
+                        ) : null}
+                        {fileCountLabel || stats ? (
+                          <span className="inline-flex min-h-7 flex-wrap items-center gap-x-2.5 gap-y-1 rounded-full bg-[var(--surface-muted)] px-3 py-1 text-[var(--muted)]">
+                            {fileCountLabel ? (
+                              <span className="hidden items-center gap-1.5 min-[420px]:flex">
+                                <Files size={12} strokeWidth={1.5} className="shrink-0" />
+                                {fileCountLabel}
+                              </span>
+                            ) : null}
+                            {stats ? (
+                              <>
+                                <span
+                                  className="flex shrink-0 items-center gap-1.5"
+                                  title={`${stats.views.toLocaleString('en')} views`}
+                                >
+                                  <Eye size={12} strokeWidth={1.6} className="shrink-0" />
+                                  {formatInteractionCount(stats.views)} views
+                                </span>
+                                <span
+                                  className="flex shrink-0 items-center gap-1.5"
+                                  title={`${stats.copies.toLocaleString('en')} copies`}
+                                >
+                                  <Copy size={12} strokeWidth={1.6} className="shrink-0" />
+                                  {formatInteractionCount(stats.copies)} copies
+                                </span>
+                              </>
+                            ) : null}
+                          </span>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
 
                   <div className="relative flex min-h-0 flex-1 flex-col">

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -234,33 +234,37 @@ export function SkillModal({
                               ) : null}
                             </span>
                           ) : null}
-                          <a
-                            href={sourceUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            onClick={() => {
-                              trackEvent('skill_source_click', {
-                                skill_slug: skill.slug,
-                                skill_name: displayName,
-                                target: 'github_skill_source',
-                              });
-                            }}
-                            className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--accent-soft)] px-3 font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--on-accent)]"
-                            title="View source file on GitHub"
-                          >
-                            <ExternalLink size={12} className="shrink-0" />
-                            View on GitHub
-                          </a>
                         </div>
                       ) : null}
                     </div>
-                    <button
-                      onClick={onClose}
-                      className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
-                      aria-label="Close skill details"
-                    >
-                      <X size={17} />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {skill ? (
+                        <a
+                          href={sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => {
+                            trackEvent('skill_source_click', {
+                              skill_slug: skill.slug,
+                              skill_name: displayName,
+                              target: 'github_skill_source',
+                            });
+                          }}
+                          className="grid h-9 w-9 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
+                          aria-label="View source on GitHub"
+                          title="View source on GitHub"
+                        >
+                          <ExternalLink size={16} strokeWidth={1.8} />
+                        </a>
+                      ) : null}
+                      <button
+                        onClick={onClose}
+                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--surface-muted)] text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--accent)]"
+                        aria-label="Close skill details"
+                      >
+                        <X size={17} />
+                      </button>
+                    </div>
                   </div>
 
                   <div className="relative flex min-h-0 flex-1 flex-col">

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -196,39 +196,43 @@ export function SkillModal({
                         {displayName}
                       </Dialog.Title>
                       {skill ? (
-                        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 text-xs">
-                          <span className="inline-flex h-7 max-w-full items-center rounded-full bg-[var(--surface-muted)] px-3 font-mono text-[11px] text-[var(--muted)]">
+                        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 font-mono text-xs">
+                          <span className="inline-flex h-7 max-w-full items-center rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
                             {skill.name}
                           </span>
                           {publishedAt ? (
                             <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
-                              <CalendarDays size={12} className="shrink-0" />
+                              <CalendarDays size={12} strokeWidth={1.5} className="shrink-0" />
                               {publishedAt}
                             </span>
                           ) : null}
-                          {fileCountLabel ? (
-                            <span className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
-                              <Files size={12} className="shrink-0" />
-                              {fileCountLabel}
+                          {fileCountLabel || stats ? (
+                            <span className="inline-flex h-7 items-center gap-2.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]">
+                              {fileCountLabel ? (
+                                <span className="flex items-center gap-1.5">
+                                  <Files size={12} strokeWidth={1.5} className="shrink-0" />
+                                  {fileCountLabel}
+                                </span>
+                              ) : null}
+                              {stats ? (
+                                <>
+                                  <span
+                                    className="flex items-center gap-1.5"
+                                    title={`${stats.views.toLocaleString('en')} views`}
+                                  >
+                                    <Eye size={12} strokeWidth={1.6} className="shrink-0" />
+                                    {formatInteractionCount(stats.views)} views
+                                  </span>
+                                  <span
+                                    className="flex items-center gap-1.5"
+                                    title={`${stats.copies.toLocaleString('en')} copies`}
+                                  >
+                                    <Copy size={12} strokeWidth={1.6} className="shrink-0" />
+                                    {formatInteractionCount(stats.copies)} copies
+                                  </span>
+                                </>
+                              ) : null}
                             </span>
-                          ) : null}
-                          {stats ? (
-                            <>
-                              <span
-                                className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]"
-                                title={`${stats.views} views`}
-                              >
-                                <Eye size={12} className="shrink-0" />
-                                {formatInteractionCount(stats.views)} views
-                              </span>
-                              <span
-                                className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 text-[var(--muted)]"
-                                title={`${stats.copies} copies`}
-                              >
-                                <Copy size={12} className="shrink-0" />
-                                {formatInteractionCount(stats.copies)} copies
-                              </span>
-                            </>
                           ) : null}
                           <a
                             href={sourceUrl}

--- a/web/src/lib/skill-stats.ts
+++ b/web/src/lib/skill-stats.ts
@@ -64,14 +64,54 @@ function statsField(slug: string, interaction: SkillInteraction) {
   return `${slug}:${interaction === 'view' ? 'views' : 'copies'}`;
 }
 
+// Deterministic in-memory stats for local development when Upstash is not
+// configured. Enable with SKILL_STATS_MOCK=true; never active in production.
+const mockStatsStore = new Map<string, SkillStats>();
+
+function isSkillStatsMocked(): boolean {
+  return (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.SKILL_STATS_MOCK === 'true'
+  );
+}
+
+function getMockStats(slug: string): SkillStats {
+  const existing = mockStatsStore.get(slug);
+
+  if (existing) {
+    return existing;
+  }
+
+  let hash = 0;
+  for (const char of slug) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+
+  const stats: SkillStats = {
+    views: 42 + (hash % 4800),
+    copies: 3 + ((hash >>> 8) % 640),
+  };
+  mockStatsStore.set(slug, stats);
+  return stats;
+}
+
 export function isSkillStatsEnabled(): boolean {
-  return getRedis() !== null;
+  return getRedis() !== null || isSkillStatsMocked();
 }
 
 export async function getSkillStats(
   slugs: string[]
 ): Promise<SkillStatsSnapshot> {
   const redis = getRedis();
+
+  if (!redis && isSkillStatsMocked()) {
+    return {
+      enabled: true,
+      skills: Object.fromEntries(
+        slugs.map((slug) => [slug, getMockStats(slug)])
+      ),
+    };
+  }
 
   if (!redis || slugs.length === 0) {
     return {
@@ -114,7 +154,13 @@ export async function recordSkillInteraction(
   const redis = getRedis();
 
   if (!redis) {
-    return null;
+    if (!isSkillStatsMocked()) {
+      return null;
+    }
+
+    const stats = getMockStats(slug);
+    stats[interaction === 'view' ? 'views' : 'copies'] += 1;
+    return { counted: true, stats };
   }
 
   try {


### PR DESCRIPTION
## Summary
Refine how public interaction statistics are presented across the marketplace so cards and skill details stay compact and responsive.

## Changes
- Move card view and copy counts into the existing metadata row and improve its readability
- Reorganize modal metadata, group interaction counts, and move the GitHub source action into the header
- Add collection-wide view and copy totals to the marketplace facts
- Add an opt-in, development-only statistics mock for local UI testing without Upstash
- Improve the modal header layout at narrow viewport widths

## Motivation
- Keep interaction data visible without adding a separate visual row to every card
- Prevent long skill metadata from crowding modal headers
- Make statistics-related UI work easier to preview locally

## Testing
- `npm run lint`
- `npm run build`

## Notes
- Set `SKILL_STATS_MOCK=true` only in local development to enable deterministic mock counts; it is disabled in production
