### PR TITLE
feat(web): add skill sorting control

### DIFF
--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -239,7 +239,10 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
     setSelectedSkill(null);
     setSkillLoadError(null);
     setIsLoadingSkill(false);
-    window.history.pushState(null, '', pathname);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('skill');
+    const queryString = params.toString();
+    window.history.pushState(null, '', `${pathname}${queryString ? `?${queryString}` : ''}`);
   };
 
   const handleStatsChange = useCallback((slug: string, stats: SkillStats) => {

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -353,17 +353,17 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '0px 0px -40px 0px' }}
           transition={{ duration: 0.3, ease: 'easeOut' }}
-          className="mb-6 flex flex-wrap items-end justify-between gap-3"
+          className="mb-6 flex flex-wrap items-center justify-between gap-3"
         >
-          <h2 id="catalog-heading" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
-            Browse skills
-          </h2>
-          <div className="flex flex-wrap items-center gap-3">
-            <SortSelect value={sortKey} options={visibleSortOptions} onChange={handleSortChange} />
+          <div className="flex items-baseline gap-2.5">
+            <h2 id="catalog-heading" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
+              Browse skills
+            </h2>
             <p className="text-sm text-[var(--muted)]" aria-live="polite">
               {orderedSkills.length} {orderedSkills.length === 1 ? 'skill' : 'skills'}
             </p>
           </div>
+          <SortSelect value={sortKey} options={visibleSortOptions} onChange={handleSortChange} />
         </motion.div>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -8,25 +8,17 @@ import { Search } from 'lucide-react';
 import { RepositoryInstallPanel } from './RepositoryInstallPanel';
 import { SkillCard } from './SkillCard';
 import { SkillModal } from './SkillModal';
+import { SortSelect } from './SortSelect';
 import { trackEvent } from '@/lib/gtag';
-import { formatInteractionCount, parseSkillMetadataDate } from '@/lib/utils';
+import { formatInteractionCount } from '@/lib/utils';
+import { DEFAULT_SORT_KEY, SORT_OPTIONS, getSkillComparator, isStatsSortKey, normalizeSortKey } from '@/lib/sorting';
+import type { SortKey } from '@/lib/sorting';
 import type { Skill, SkillMetadata } from '@/lib/skills';
 import type { SkillStats, SkillStatsSnapshot } from '@/lib/skill-stats';
 
 interface MarketplaceProps {
   initialSkills: SkillMetadata[];
   initialStats: SkillStatsSnapshot;
-}
-
-function compareSkillsByCreated(left: SkillMetadata, right: SkillMetadata) {
-  const leftTime = parseSkillMetadataDate(left.metadata?.created)?.getTime() ?? 0;
-  const rightTime = parseSkillMetadataDate(right.metadata?.created)?.getTime() ?? 0;
-
-  if (leftTime !== rightTime) {
-    return rightTime - leftTime;
-  }
-
-  return left.name.localeCompare(right.name);
 }
 
 const heroContainer: Variants = {
@@ -76,6 +68,14 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
   const [isLoadingSkill, setIsLoadingSkill] = useState(false);
   const [skillLoadError, setSkillLoadError] = useState<string | null>(null);
   const [statsSnapshot, setStatsSnapshot] = useState(initialStats);
+  const requestedSortKey = normalizeSortKey(searchParams.get('sort'));
+  const sortKey: SortKey =
+    isStatsSortKey(requestedSortKey) && !statsSnapshot.enabled
+      ? DEFAULT_SORT_KEY
+      : requestedSortKey;
+  const visibleSortOptions = SORT_OPTIONS.filter(
+    (option) => !option.requiresStats || statsSnapshot.enabled
+  );
   // Hydration-safe mount flag without setState-in-effect: false during SSR
   // and the first client render, true afterwards.
   const hasMounted = useSyncExternalStore(
@@ -169,8 +169,8 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
           displayDescription.toLowerCase().includes(normalizedSearch)
         );
       })
-      .sort(compareSkillsByCreated);
-  }, [initialSkills, search]);
+      .sort(getSkillComparator(sortKey, statsSnapshot));
+  }, [initialSkills, search, sortKey, statsSnapshot]);
 
   const totalSkills = initialSkills.length;
   const isSearching = search.trim().length > 0;
@@ -221,6 +221,18 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
     const params = new URLSearchParams(searchParams.toString());
     params.set('skill', skillMeta.slug);
     window.history.pushState(null, '', `${pathname}?${params.toString()}`);
+  };
+
+  const handleSortChange = (key: SortKey) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (key === DEFAULT_SORT_KEY) {
+      params.delete('sort');
+    } else {
+      params.set('sort', key);
+    }
+    const queryString = params.toString();
+    window.history.pushState(null, '', `${pathname}${queryString ? `?${queryString}` : ''}`);
+    trackEvent('skill_sort', { sort_key: key });
   };
 
   const handleCloseModal = () => {
@@ -346,9 +358,12 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
           <h2 id="catalog-heading" className="font-display text-2xl font-bold tracking-tight text-[var(--foreground)] sm:text-3xl">
             Browse skills
           </h2>
-          <p className="text-sm text-[var(--muted)]" aria-live="polite">
-            {orderedSkills.length} {orderedSkills.length === 1 ? 'skill' : 'skills'}
-          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <SortSelect value={sortKey} options={visibleSortOptions} onChange={handleSortChange} />
+            <p className="text-sm text-[var(--muted)]" aria-live="polite">
+              {orderedSkills.length} {orderedSkills.length === 1 ? 'skill' : 'skills'}
+            </p>
+          </div>
         </motion.div>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/src/components/SortSelect.tsx
+++ b/web/src/components/SortSelect.tsx
@@ -25,7 +25,7 @@ export function SortSelect({ value, options, onChange }: SortSelectProps) {
   return (
     <div className="relative">
       <Listbox value={value} onChange={onChange}>
-        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] pl-3.5 pr-2.5 text-sm text-[var(--foreground)] shadow-[var(--shadow-card)] transition-[border-color,box-shadow] hover:border-[var(--border-strong)] focus-visible:outline-offset-2">
+        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] pl-3.5 pr-2.5 text-sm text-[var(--foreground)] shadow-[var(--shadow-card)] transition-[border-color,box-shadow] hover:border-[var(--border-strong)] focus:outline-none data-[focus]:ring-2 data-[focus]:ring-[var(--accent)]">
           <ArrowUpDown size={13} strokeWidth={2} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
           <span className="sr-only">Sort skills</span>
           <span className="truncate">{currentOption.label}</span>
@@ -36,12 +36,12 @@ export function SortSelect({ value, options, onChange }: SortSelectProps) {
             aria-hidden="true"
           />
         </ListboxButton>
-        <ListboxOptions className="absolute right-0 z-30 mt-2 w-44 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1.5 shadow-[var(--shadow-modal)]">
+        <ListboxOptions className="absolute right-0 z-30 mt-2 w-44 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1.5 shadow-[var(--shadow-modal)] focus:outline-none">
           {options.map((option) => (
             <ListboxOption
               key={option.key}
               value={option.key}
-              className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm text-[var(--muted)] transition-colors hover:bg-[var(--surface-muted)] data-[focus]:bg-[var(--surface-muted)]"
+              className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm text-[var(--muted)] transition-colors hover:bg-[var(--surface-muted)] data-[focus]:bg-[var(--surface-muted)] focus:outline-none"
             >
               {({ selected }) => (
                 <>

--- a/web/src/components/SortSelect.tsx
+++ b/web/src/components/SortSelect.tsx
@@ -25,14 +25,14 @@ export function SortSelect({ value, options, onChange }: SortSelectProps) {
   return (
     <div className="relative">
       <Listbox value={value} onChange={onChange}>
-        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] pl-3.5 pr-2.5 text-sm text-[var(--foreground)] shadow-[var(--shadow-card)] transition-[border-color,box-shadow] hover:border-[var(--border-strong)] focus:outline-none data-[focus]:ring-2 data-[focus]:ring-[var(--accent)]">
-          <ArrowUpDown size={13} strokeWidth={2} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
+        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-transparent px-3 text-sm text-[var(--muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--foreground)] focus:outline-none data-[focus]:ring-2 data-[focus]:ring-[var(--accent)]">
+          <ArrowUpDown size={13} strokeWidth={2} className="shrink-0" aria-hidden="true" />
           <span className="sr-only">Sort skills</span>
           <span className="truncate">{currentOption.label}</span>
           <ChevronDown
             size={14}
             strokeWidth={2}
-            className="shrink-0 text-[var(--muted)] transition-transform duration-200 group-data-[open]:rotate-180"
+            className="shrink-0 transition-transform duration-200 group-data-[open]:rotate-180"
             aria-hidden="true"
           />
         </ListboxButton>

--- a/web/src/components/SortSelect.tsx
+++ b/web/src/components/SortSelect.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/react';
+import { ArrowUpDown, Check, ChevronDown } from 'lucide-react';
+import type { SortKey, SortOption } from '@/lib/sorting';
+
+interface SortSelectProps {
+  value: SortKey;
+  options: SortOption[];
+  onChange: (key: SortKey) => void;
+}
+
+export function SortSelect({ value, options, onChange }: SortSelectProps) {
+  const currentOption = options.find((option) => option.key === value) ?? options[0];
+
+  if (!currentOption) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      <Listbox value={value} onChange={onChange}>
+        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] pl-3.5 pr-2.5 text-sm text-[var(--foreground)] shadow-[var(--shadow-card)] transition-[border-color,box-shadow] hover:border-[var(--border-strong)] focus-visible:outline-offset-2">
+          <ArrowUpDown size={13} strokeWidth={2} className="shrink-0 text-[var(--muted)]" aria-hidden="true" />
+          <span className="sr-only">Sort skills</span>
+          <span className="truncate">{currentOption.label}</span>
+          <ChevronDown
+            size={14}
+            strokeWidth={2}
+            className="shrink-0 text-[var(--muted)] transition-transform duration-200 group-data-[open]:rotate-180"
+            aria-hidden="true"
+          />
+        </ListboxButton>
+        <ListboxOptions className="absolute right-0 z-30 mt-2 w-44 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1.5 shadow-[var(--shadow-modal)]">
+          {options.map((option) => (
+            <ListboxOption
+              key={option.key}
+              value={option.key}
+              className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm text-[var(--muted)] transition-colors hover:bg-[var(--surface-muted)] data-[focus]:bg-[var(--surface-muted)]"
+            >
+              {({ selected }) => (
+                <>
+                  <span className={selected ? 'font-semibold text-[var(--foreground)]' : undefined}>
+                    {option.label}
+                  </span>
+                  {selected ? (
+                    <Check size={14} strokeWidth={2} className="shrink-0 text-[var(--accent)]" aria-hidden="true" />
+                  ) : null}
+                </>
+              )}
+            </ListboxOption>
+          ))}
+        </ListboxOptions>
+      </Listbox>
+    </div>
+  );
+}

--- a/web/src/components/SortSelect.tsx
+++ b/web/src/components/SortSelect.tsx
@@ -25,7 +25,7 @@ export function SortSelect({ value, options, onChange }: SortSelectProps) {
   return (
     <div className="relative">
       <Listbox value={value} onChange={onChange}>
-        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-transparent px-3 text-sm text-[var(--muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--foreground)] focus:outline-none data-[focus]:ring-2 data-[focus]:ring-[var(--accent)]">
+        <ListboxButton className="group flex h-9 items-center gap-2 rounded-full border border-transparent px-3 text-sm text-[var(--muted)] transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--surface)] hover:text-[var(--foreground)] focus:outline-none data-[focus]:ring-2 data-[focus]:ring-[var(--accent)]">
           <ArrowUpDown size={13} strokeWidth={2} className="shrink-0" aria-hidden="true" />
           <span className="sr-only">Sort skills</span>
           <span className="truncate">{currentOption.label}</span>

--- a/web/src/lib/sorting.ts
+++ b/web/src/lib/sorting.ts
@@ -1,0 +1,112 @@
+import type { SkillMetadata } from './skills';
+import type { SkillStatsSnapshot } from './skill-stats';
+import { parseSkillMetadataDate } from './utils';
+
+export type SortKey =
+  | 'newest'
+  | 'oldest'
+  | 'name-asc'
+  | 'name-desc'
+  | 'views-desc'
+  | 'copies-desc';
+
+export interface SortOption {
+  key: SortKey;
+  label: string;
+  requiresStats: boolean;
+}
+
+export const DEFAULT_SORT_KEY: SortKey = 'newest';
+
+export const SORT_OPTIONS: SortOption[] = [
+  { key: 'newest', label: 'Newest', requiresStats: false },
+  { key: 'oldest', label: 'Oldest', requiresStats: false },
+  { key: 'name-asc', label: 'Name A–Z', requiresStats: false },
+  { key: 'name-desc', label: 'Name Z–A', requiresStats: false },
+  { key: 'views-desc', label: 'Most viewed', requiresStats: true },
+  { key: 'copies-desc', label: 'Most copied', requiresStats: true },
+];
+
+export function isSortKey(value: unknown): value is SortKey {
+  return typeof value === 'string' && SORT_OPTIONS.some((option) => option.key === value);
+}
+
+export function normalizeSortKey(value: string | null | undefined): SortKey {
+  return isSortKey(value) ? value : DEFAULT_SORT_KEY;
+}
+
+export function isStatsSortKey(key: SortKey): boolean {
+  return SORT_OPTIONS.find((option) => option.key === key)?.requiresStats ?? false;
+}
+
+function displayNameOf(skill: SkillMetadata): string {
+  return skill.metadata?.name ?? skill.name;
+}
+
+function createdTimeOf(skill: SkillMetadata): number | null {
+  const date = parseSkillMetadataDate(skill.metadata?.created);
+  return date ? date.getTime() : null;
+}
+
+function compareDisplayNames(left: SkillMetadata, right: SkillMetadata): number {
+  return displayNameOf(left).localeCompare(displayNameOf(right), undefined, {
+    sensitivity: 'base',
+  });
+}
+
+// Skills without a creation date sort last regardless of direction.
+function compareCreated(
+  left: SkillMetadata,
+  right: SkillMetadata,
+  ascending: boolean
+): number {
+  const leftTime = createdTimeOf(left);
+  const rightTime = createdTimeOf(right);
+
+  if (leftTime !== null && rightTime !== null) {
+    return ascending ? leftTime - rightTime : rightTime - leftTime;
+  }
+
+  if (leftTime === null && rightTime === null) {
+    return compareDisplayNames(left, right);
+  }
+
+  return leftTime === null ? 1 : -1;
+}
+
+function compareInteraction(
+  left: SkillMetadata,
+  right: SkillMetadata,
+  stats: SkillStatsSnapshot | undefined,
+  field: 'views' | 'copies'
+): number {
+  const leftCount = stats?.skills[left.slug]?.[field] ?? 0;
+  const rightCount = stats?.skills[right.slug]?.[field] ?? 0;
+
+  if (leftCount !== rightCount) {
+    return rightCount - leftCount;
+  }
+
+  return compareDisplayNames(left, right);
+}
+
+export function getSkillComparator(
+  key: SortKey,
+  stats?: SkillStatsSnapshot
+): (left: SkillMetadata, right: SkillMetadata) => number {
+  switch (key) {
+    case 'oldest':
+      return (left, right) => compareCreated(left, right, true);
+    case 'name-asc':
+      return (left, right) => compareDisplayNames(left, right);
+    case 'name-desc':
+      return (left, right) => compareDisplayNames(right, left);
+    case 'views-desc':
+      return (left, right) => compareInteraction(left, right, stats, 'views');
+    case 'copies-desc':
+      return (left, right) => compareInteraction(left, right, stats, 'copies');
+    case 'newest':
+    default:
+      return (left, right) => compareCreated(left, right, false);
+  }
+}


### PR DESCRIPTION
## Summary
Add sorting controls to the "Browse skills" catalog so users can order skills by creation date, name, or interaction count, with the selection synced to the `?sort=` URL parameter.

## Changes
- Add `web/src/lib/sorting.ts`: `SortKey` type, `SORT_OPTIONS`, and `getSkillComparator` pure functions (moves the existing `compareSkillsByCreated`).
- Add `web/src/components/SortSelect.tsx`: a HeadlessUI `Listbox` dropdown styled to match the design system; stats-dependent options are hidden when interaction stats are unavailable.
- Update `web/src/components/Marketplace.tsx` to derive sort from `?sort=`, sort the grid, render the control, and emit a `skill_sort` GA event.
- Keep `Newest` as the default so existing newest-first ordering is unchanged.

## Motivation
- The catalog was previously hard-coded to newest-first; this lets users browse by name or popularity.
- Syncing to `?sort=` makes the selection shareable and preserves it across refresh and back/forward.

## Testing
- npm run lint
- npm run build