### PR TITLE
feat(design-workflow-graphs): add workflow graph design skill

### DIFF
--- a/skills/design-workflow-graphs/SKILL.md
+++ b/skills/design-workflow-graphs/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   name: Design Workflow Graphs
   description: Design and review reliable graph-based workflows with explicit control flow, state, failure, and termination semantics.
   author: FLC
-  created: "2026-08-18T14:22:56Z"
+  created: "2026-08-18T15:14:41Z"
 ---
 
 # Design Workflow Graphs
@@ -31,7 +31,7 @@ Load only what the request needs:
 - For reusable topologies, read [references/graph-patterns.md](references/graph-patterns.md).
 - For audits or final design review, read [references/review-checklist.md](references/review-checklist.md).
 - To create a machine-readable artifact, copy [assets/graph-spec.json](assets/graph-spec.json) and adapt it.
-- To validate a Graph Spec, run `python3 scripts/validate_graph_spec.py path/to/graph.json`.
+- To validate a Graph Spec, run `python3 scripts/validate_graph_spec.py --strict path/to/graph.json`.
 
 ## Choose the Work Mode
 
@@ -84,6 +84,8 @@ List every shared state field and define:
 
 Keep large artifacts outside shared state when a reference is sufficient. Do not use conversation history as an implicit state schema.
 
+In a Graph Spec, declare `state.writers` as the complete authorization set. It must exactly match the nodes that list the field under `writes`. Mark fields available before entry with `initial: true`; every node read must be available on every normal or recovery path into that node.
+
 ### 4. Define node contracts
 
 Give every node one primary responsibility. Specify:
@@ -97,6 +99,8 @@ Give every node one primary responsibility. Specify:
 
 Split a node when its outputs need different retry, permission, evaluation, or ownership semantics. Merge nodes when separation creates no meaningful control boundary.
 
+Classify each non-terminal node's exhausted failure as `retryable`, `correctable`, `rejectable`, or `terminal`, and route it to an explicit `on_failure` node.
+
 ### 5. Define edges and routing
 
 For every edge, define its source, destination, and reason for selection.
@@ -104,22 +108,34 @@ For every edge, define its source, destination, and reason for selection.
 - Make conditional routes collectively exhaustive.
 - Make conditions mutually exclusive or define priority explicitly.
 - Add a default route for unclassified results.
+- Declare each guard's state dependencies under edge `reads`.
 - Keep routing decisions based on explicit state, not hidden prompt context.
 - Distinguish alternative branches from fan-out parallelism.
+
+Use distinct positive priorities whenever multiple guarded edges leave the same node. Treat the validator as a structural check: arbitrary guard expressions still need runtime-specific tests for meaning, overlap, and boundary behavior.
 
 ### 6. Add joins, loops, and approvals
 
 For parallel work, define branch isolation, join policy, timeout behavior, partial-result policy, and state merge semantics.
+
+Do not allow concurrent branches to write the same `replace` or `reject-conflict` field. Use independently owned fields, or an explicit `append` or `reduce` contract when concurrent aggregation is intentional.
 
 For every loop, define:
 
 - loop members
 - progress signal
 - exit condition
+- member after which the exit condition is evaluated
 - maximum iterations, duration, or cost
 - behavior when the budget is exhausted
 
+Require the declared loop members to match the actual cyclic component exactly. Do not add downstream nodes merely to make an exit condition appear available.
+
 Represent human approval as an explicit resumable boundary. Persist the decision input, approver identity when required, decision, and continuation state.
+
+Make approval rejection, expiry, loop exhaustion, partial failure, unhandled failure, and cancellation resolve to explicit nodes rather than free-form outcomes.
+
+Include these implicit failure and recovery transitions when checking reachability and cycles. Re-entering normal work from recovery requires its own measurable loop boundary.
 
 ### 7. Design failure and side-effect behavior
 
@@ -145,9 +161,9 @@ Define evaluation at the smallest useful level:
 
 ### 9. Validate and deliver
 
-Read [references/review-checklist.md](references/review-checklist.md). When producing a Graph Spec, run the bundled validator and fix errors before handoff.
+Read [references/review-checklist.md](references/review-checklist.md). When producing a Graph Spec, run the bundled validator in strict mode and fix errors and warnings before handoff.
 
-Treat warnings as design questions. Explain any warning intentionally retained.
+The validator checks structural contracts and reference integrity. It does not interpret arbitrary guard languages or prove runtime behavior; add execution tests for route boundaries, recovery, resume, and side-effect semantics.
 
 ## Deliverables
 
@@ -174,9 +190,14 @@ Before finishing, verify that:
 - every terminal state is explicit
 - every branch has total routing behavior
 - every join defines completion and merge semantics
+- every quorum is achievable from its incoming paths
 - every cycle has a measurable bound and exhaustion path
 - concurrent writers have a declared merge or conflict policy
 - retries cannot duplicate unsafe side effects
 - approval and resume state can survive process interruption
+- failure, cancellation, and partial-result routes resolve to nodes
+- node reads are initialized on every normal and recovery arrival path
+- failure and recovery routes cannot create undeclared cycles
+- evaluation checks identify resolvable targets and stable metrics
 - observability can explain which edge ran and why
 - the design can be understood without framework-specific source code

--- a/skills/design-workflow-graphs/SKILL.md
+++ b/skills/design-workflow-graphs/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: design-workflow-graphs
+description: Design, transform, review, and evolve graph-based workflows with explicit state, nodes, edges, routing, concurrency, joins, loops, approvals, recovery, termination, side effects, and observability. Use when Codex needs to decide whether graph orchestration fits a process; turn requirements, a linear workflow, or an agent loop into a workflow graph; audit an existing DAG or state graph; or produce a framework-neutral graph specification before implementation.
+metadata:
+  name: Design Workflow Graphs
+  description: Design and review reliable graph-based workflows with explicit control flow, state, failure, and termination semantics.
+  author: FLC
+  created: "2026-08-18T14:22:56Z"
+---
+
+# Design Workflow Graphs
+
+Design workflow graphs as explicit engineering contracts rather than decorative diagrams. Make control flow, state mutation, termination, failure behavior, and side effects reviewable before choosing an execution framework.
+
+## Operating Principles
+
+- Start from the objective, state, and termination contract; do not start by inventing agents or nodes.
+- Use a graph only when branching, parallelism, bounded iteration, durable recovery, approval gates, or independently observable stages justify it.
+- Prefer a linear workflow or one bounded agent loop when it is sufficient.
+- Keep deterministic control in edges, guards, budgets, and validation. Use model reasoning inside nodes only where judgment is required.
+- Give each state field and side effect an owner.
+- Bound every cycle by attempts, elapsed time, cost, or another measurable budget.
+- Place irreversible side effects after validation and approval whenever possible.
+- Keep the core design framework-neutral. Map it to a runtime only after the graph contract is stable.
+
+## Resource Map
+
+Load only what the request needs:
+
+- For field definitions and invariants, read [references/graph-model.md](references/graph-model.md).
+- For reusable topologies, read [references/graph-patterns.md](references/graph-patterns.md).
+- For audits or final design review, read [references/review-checklist.md](references/review-checklist.md).
+- To create a machine-readable artifact, copy [assets/graph-spec.json](assets/graph-spec.json) and adapt it.
+- To validate a Graph Spec, run `python3 scripts/validate_graph_spec.py path/to/graph.json`.
+
+## Choose the Work Mode
+
+Choose one primary mode and state it when the distinction affects the deliverable:
+
+- `design`: Create a new workflow graph from goals and constraints.
+- `transform`: Convert a linear process, implicit agent loop, or prose procedure into an explicit graph.
+- `review`: Find structural, state, concurrency, recovery, termination, and side-effect defects in an existing graph.
+- `evolve`: Revise a graph using observed failures, traces, evaluation results, or changed requirements.
+
+Do not force the full design workflow onto a narrow request. For example, review only the supplied graph when the user asks for an audit.
+
+## Design Workflow
+
+### 1. Frame the contract
+
+Establish:
+
+- objective and measurable completion criteria
+- inputs, outputs, actors, systems, and trust boundaries
+- irreversible actions and required approvals
+- latency, cost, reliability, and compliance constraints
+- what must persist across retries or pauses
+
+Separate known facts, bounded assumptions, and decisions. Ask only when a missing decision would materially change topology or safety.
+
+### 2. Decide whether a graph is warranted
+
+Use a graph when at least one material requirement needs explicit topology:
+
+- conditional routing with different downstream work
+- parallel branches followed by defined aggregation
+- iteration with measurable exit conditions
+- pause and resume, durable recovery, or human approval
+- stages with different permissions or side-effect boundaries
+- independent node-level observability or evaluation
+
+Recommend a simpler pipeline or loop when the graph adds ceremony without improving control, recovery, or understanding.
+
+### 3. Define state before nodes
+
+List every shared state field and define:
+
+- meaning and type
+- initial source
+- owner or authorized writers
+- merge strategy for concurrent or repeated writes
+- persistence and sensitivity requirements
+- retention or deletion rule when material
+
+Keep large artifacts outside shared state when a reference is sufficient. Do not use conversation history as an implicit state schema.
+
+### 4. Define node contracts
+
+Give every node one primary responsibility. Specify:
+
+- required reads and produced writes
+- deterministic work versus model judgment
+- tools, permissions, and external dependencies
+- timeout and retry policy
+- idempotency and side effects
+- success, failure, and cancellation outcomes
+
+Split a node when its outputs need different retry, permission, evaluation, or ownership semantics. Merge nodes when separation creates no meaningful control boundary.
+
+### 5. Define edges and routing
+
+For every edge, define its source, destination, and reason for selection.
+
+- Make conditional routes collectively exhaustive.
+- Make conditions mutually exclusive or define priority explicitly.
+- Add a default route for unclassified results.
+- Keep routing decisions based on explicit state, not hidden prompt context.
+- Distinguish alternative branches from fan-out parallelism.
+
+### 6. Add joins, loops, and approvals
+
+For parallel work, define branch isolation, join policy, timeout behavior, partial-result policy, and state merge semantics.
+
+For every loop, define:
+
+- loop members
+- progress signal
+- exit condition
+- maximum iterations, duration, or cost
+- behavior when the budget is exhausted
+
+Represent human approval as an explicit resumable boundary. Persist the decision input, approver identity when required, decision, and continuation state.
+
+### 7. Design failure and side-effect behavior
+
+Classify failures as retryable, correctable, rejectable, or terminal. Prefer local recovery over restarting the entire graph.
+
+- Retry only when the operation is safe or protected by an idempotency key.
+- Route correctable output to a bounded repair path.
+- Define compensation for completed irreversible steps when rollback matters.
+- Preserve enough checkpoint state to resume without repeating successful side effects.
+- Define timeout, cancellation, and partial-completion behavior.
+
+### 8. Add observability and evaluation
+
+Capture at least node start, node end, selected edge, state delta, latency, retry, and error events. Redact sensitive values.
+
+Define evaluation at the smallest useful level:
+
+- node output quality
+- route-selection correctness
+- join or reduction correctness
+- loop progress and budget use
+- end-to-end completion and side-effect correctness
+
+### 9. Validate and deliver
+
+Read [references/review-checklist.md](references/review-checklist.md). When producing a Graph Spec, run the bundled validator and fix errors before handoff.
+
+Treat warnings as design questions. Explain any warning intentionally retained.
+
+## Deliverables
+
+Match the output to the request. A complete design should normally include:
+
+1. **Suitability decision**: Why a graph, pipeline, or loop is appropriate.
+2. **Assumptions and constraints**: Facts, decisions, and unresolved gates.
+3. **State contract**: Fields, writers, merge rules, persistence, and sensitivity.
+4. **Node contracts**: Responsibilities, reads, writes, retries, and side effects.
+5. **Edge contracts**: Routing conditions, defaults, fan-out, joins, and loop exits.
+6. **Topology**: A compact Mermaid flowchart.
+7. **Graph Spec**: A machine-readable JSON artifact when implementation or validation is expected.
+8. **Risk review**: Termination, concurrency, recovery, approval, and observability findings.
+9. **Implementation handoff**: Runtime-specific mapping only when requested.
+
+For reviews, lead with findings ordered by severity and cite the affected nodes, edges, or state fields. Do not redesign unaffected areas unless needed to demonstrate a fix.
+
+## Quality Bar
+
+Before finishing, verify that:
+
+- every node is reachable from the entry
+- every non-terminal node has an outgoing path
+- every terminal state is explicit
+- every branch has total routing behavior
+- every join defines completion and merge semantics
+- every cycle has a measurable bound and exhaustion path
+- concurrent writers have a declared merge or conflict policy
+- retries cannot duplicate unsafe side effects
+- approval and resume state can survive process interruption
+- observability can explain which edge ran and why
+- the design can be understood without framework-specific source code

--- a/skills/design-workflow-graphs/SKILL.md
+++ b/skills/design-workflow-graphs/SKILL.md
@@ -116,7 +116,7 @@ Use distinct positive priorities whenever multiple guarded edges leave the same 
 
 ### 6. Add joins, loops, and approvals
 
-For parallel work, define branch isolation, join policy, timeout behavior, partial-result policy, and state merge semantics.
+For parallel work, define the fan-out source, exact direct branch entries, join policy, timeout behavior, partial-result policy, and state merge semantics. Require every node with multiple unconditional outgoing edges to have exactly one matching parallel group; never model guarded or default alternatives as parallel branches. Reject normal or recovery entries from outside a branch, normal exits that bypass the group join, branch-local exceptional exits that bypass `on_partial_failure`, non-branch inputs to the join, and reuse of one join by multiple groups. Keep graph-wide cancellation and unhandled-error recovery separate.
 
 Do not allow concurrent branches to write the same `replace` or `reject-conflict` field. Use independently owned fields, or an explicit `append` or `reduce` contract when concurrent aggregation is intentional.
 

--- a/skills/design-workflow-graphs/agents/openai.yaml
+++ b/skills/design-workflow-graphs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Design Workflow Graphs"
+  short_description: "Design and review reliable workflow graphs"
+  default_prompt: "Use $design-workflow-graphs to design a reliable workflow graph for this process."

--- a/skills/design-workflow-graphs/assets/graph-spec.json
+++ b/skills/design-workflow-graphs/assets/graph-spec.json
@@ -5,7 +5,8 @@
     "goal": "Produce, review, and publish an approved proposal.",
     "entry": "intake",
     "terminals": [
-      "done"
+      "done",
+      "failed"
     ],
     "controls": {
       "max_steps": 20,
@@ -16,42 +17,81 @@
     {
       "name": "request",
       "description": "Original request and acceptance criteria.",
+      "type": "object",
       "owner": "input",
+      "writers": [
+        "intake"
+      ],
       "merge": "replace",
       "sensitive": false,
-      "persist": true
+      "persist": true,
+      "initial": false
     },
     {
       "name": "research",
       "description": "Evidence collected for the proposal.",
+      "type": "object",
       "owner": "research",
+      "writers": [
+        "research"
+      ],
       "merge": "replace",
       "sensitive": false,
-      "persist": true
+      "persist": true,
+      "initial": false
     },
     {
       "name": "risks",
       "description": "Identified risks and mitigations.",
+      "type": "object",
       "owner": "risk_assessment",
+      "writers": [
+        "risk_assessment"
+      ],
       "merge": "replace",
       "sensitive": false,
-      "persist": true
+      "persist": true,
+      "initial": false
     },
     {
       "name": "proposal",
       "description": "Current proposal candidate.",
+      "type": "object",
       "owner": "synthesize",
+      "writers": [
+        "synthesize",
+        "revise"
+      ],
       "merge": "replace",
       "sensitive": false,
-      "persist": true
+      "persist": true,
+      "initial": false
     },
     {
       "name": "review_decision",
       "description": "Structured review outcome and feedback.",
+      "type": "object",
       "owner": "review",
+      "writers": [
+        "review"
+      ],
       "merge": "replace",
       "sensitive": false,
-      "persist": true
+      "persist": true,
+      "initial": false
+    },
+    {
+      "name": "approval_decision",
+      "description": "Durable approval outcome used to resume publication.",
+      "type": "object",
+      "owner": "approval",
+      "writers": [
+        "approval"
+      ],
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true,
+      "initial": false
     }
   ],
   "nodes": [
@@ -72,6 +112,10 @@
       "timeout": "1m",
       "retry": {
         "max_attempts": 1
+      },
+      "failure": {
+        "classification": "terminal",
+        "on_failure": "failed"
       }
     },
     {
@@ -91,6 +135,10 @@
       "timeout": "5m",
       "retry": {
         "max_attempts": 2
+      },
+      "failure": {
+        "classification": "retryable",
+        "on_failure": "failed"
       }
     },
     {
@@ -110,6 +158,10 @@
       "timeout": "5m",
       "retry": {
         "max_attempts": 2
+      },
+      "failure": {
+        "classification": "retryable",
+        "on_failure": "failed"
       }
     },
     {
@@ -131,6 +183,10 @@
       "timeout": "3m",
       "retry": {
         "max_attempts": 1
+      },
+      "failure": {
+        "classification": "correctable",
+        "on_failure": "failed"
       },
       "join": {
         "strategy": "all"
@@ -154,6 +210,10 @@
       "timeout": "2m",
       "retry": {
         "max_attempts": 1
+      },
+      "failure": {
+        "classification": "correctable",
+        "on_failure": "failed"
       }
     },
     {
@@ -174,6 +234,45 @@
       "timeout": "3m",
       "retry": {
         "max_attempts": 1
+      },
+      "failure": {
+        "classification": "correctable",
+        "on_failure": "failed"
+      }
+    },
+    {
+      "id": "approval",
+      "kind": "approval",
+      "purpose": "Pause for a durable external approval decision.",
+      "reads": [
+        "request",
+        "proposal",
+        "review_decision"
+      ],
+      "writes": [
+        "approval_decision"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "24h",
+      "retry": {
+        "max_attempts": 1
+      },
+      "failure": {
+        "classification": "rejectable",
+        "on_failure": "failed"
+      },
+      "approval": {
+        "decision_state": "approval_decision",
+        "resume_state": [
+          "request",
+          "proposal",
+          "review_decision"
+        ],
+        "on_rejected": "failed",
+        "on_expired": "failed"
       }
     },
     {
@@ -193,6 +292,10 @@
       "timeout": "2m",
       "retry": {
         "max_attempts": 2
+      },
+      "failure": {
+        "classification": "retryable",
+        "on_failure": "failed"
       }
     },
     {
@@ -201,6 +304,25 @@
       "purpose": "Mark the workflow complete.",
       "reads": [
         "proposal"
+      ],
+      "writes": [
+
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "1m",
+      "retry": {
+        "max_attempts": 1
+      }
+    },
+    {
+      "id": "failed",
+      "kind": "terminal",
+      "purpose": "End the workflow after rejection, exhaustion, cancellation, or failure.",
+      "reads": [
+
       ],
       "writes": [
 
@@ -238,8 +360,11 @@
     },
     {
       "from": "review",
-      "to": "publish",
-      "when": "review_decision.status == \"approved\""
+      "to": "approval",
+      "when": "review_decision.status == \"approved\"",
+      "reads": [
+        "review_decision"
+      ]
     },
     {
       "from": "review",
@@ -249,6 +374,19 @@
     {
       "from": "revise",
       "to": "review"
+    },
+    {
+      "from": "approval",
+      "to": "publish",
+      "when": "approval_decision.status == \"approved\"",
+      "reads": [
+        "approval_decision"
+      ]
+    },
+    {
+      "from": "approval",
+      "to": "failed",
+      "default": true
     },
     {
       "from": "publish",
@@ -263,7 +401,7 @@
         "risk_assessment"
       ],
       "join": "synthesize",
-      "on_partial_failure": "fail"
+      "on_partial_failure": "failed"
     }
   ],
   "loops": [
@@ -274,10 +412,38 @@
         "revise"
       ],
       "exit_when": "review_decision.status == \"approved\"",
+      "reads": [
+        "review_decision"
+      ],
+      "evaluate_after": "review",
       "max_iterations": 3,
-      "on_exhausted": "fail"
+      "on_exhausted": "failed"
     }
   ],
+  "recovery": {
+    "checkpoint_state": [
+      "request",
+      "proposal",
+      "review_decision",
+      "approval_decision"
+    ],
+    "on_unhandled_error": "failed",
+    "on_cancel": "failed"
+  },
+  "evaluation": {
+    "checks": [
+      {
+        "scope": "route",
+        "target": "review",
+        "metric": "review_route_accuracy"
+      },
+      {
+        "scope": "graph",
+        "target": "proposal_workflow",
+        "metric": "approved_proposal_published_once"
+      }
+    ]
+  },
   "observability": {
     "capture": [
       "node_start",

--- a/skills/design-workflow-graphs/assets/graph-spec.json
+++ b/skills/design-workflow-graphs/assets/graph-spec.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "1",
+  "graph": {
+    "id": "proposal_workflow",
+    "goal": "Produce, review, and publish an approved proposal.",
+    "entry": "intake",
+    "terminals": [
+      "done"
+    ],
+    "controls": {
+      "max_steps": 20,
+      "timeout": "30m"
+    }
+  },
+  "state": [
+    {
+      "name": "request",
+      "description": "Original request and acceptance criteria.",
+      "owner": "input",
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true
+    },
+    {
+      "name": "research",
+      "description": "Evidence collected for the proposal.",
+      "owner": "research",
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true
+    },
+    {
+      "name": "risks",
+      "description": "Identified risks and mitigations.",
+      "owner": "risk_assessment",
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true
+    },
+    {
+      "name": "proposal",
+      "description": "Current proposal candidate.",
+      "owner": "synthesize",
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true
+    },
+    {
+      "name": "review_decision",
+      "description": "Structured review outcome and feedback.",
+      "owner": "review",
+      "merge": "replace",
+      "sensitive": false,
+      "persist": true
+    }
+  ],
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "task",
+      "purpose": "Normalize the request and acceptance criteria.",
+      "reads": [
+
+      ],
+      "writes": [
+        "request"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "1m",
+      "retry": {
+        "max_attempts": 1
+      }
+    },
+    {
+      "id": "research",
+      "kind": "task",
+      "purpose": "Gather evidence relevant to the request.",
+      "reads": [
+        "request"
+      ],
+      "writes": [
+        "research"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "5m",
+      "retry": {
+        "max_attempts": 2
+      }
+    },
+    {
+      "id": "risk_assessment",
+      "kind": "task",
+      "purpose": "Identify material risks and mitigations.",
+      "reads": [
+        "request"
+      ],
+      "writes": [
+        "risks"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "5m",
+      "retry": {
+        "max_attempts": 2
+      }
+    },
+    {
+      "id": "synthesize",
+      "kind": "join",
+      "purpose": "Combine evidence and risks into a proposal.",
+      "reads": [
+        "request",
+        "research",
+        "risks"
+      ],
+      "writes": [
+        "proposal"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "3m",
+      "retry": {
+        "max_attempts": 1
+      },
+      "join": {
+        "strategy": "all"
+      }
+    },
+    {
+      "id": "review",
+      "kind": "router",
+      "purpose": "Decide whether the proposal meets the acceptance criteria.",
+      "reads": [
+        "request",
+        "proposal"
+      ],
+      "writes": [
+        "review_decision"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "2m",
+      "retry": {
+        "max_attempts": 1
+      }
+    },
+    {
+      "id": "revise",
+      "kind": "task",
+      "purpose": "Revise the proposal using actionable review feedback.",
+      "reads": [
+        "proposal",
+        "review_decision"
+      ],
+      "writes": [
+        "proposal"
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "3m",
+      "retry": {
+        "max_attempts": 1
+      }
+    },
+    {
+      "id": "publish",
+      "kind": "side_effect",
+      "purpose": "Publish the approved proposal exactly once.",
+      "reads": [
+        "proposal"
+      ],
+      "writes": [
+
+      ],
+      "side_effects": [
+        "publish_proposal"
+      ],
+      "idempotent": true,
+      "timeout": "2m",
+      "retry": {
+        "max_attempts": 2
+      }
+    },
+    {
+      "id": "done",
+      "kind": "terminal",
+      "purpose": "Mark the workflow complete.",
+      "reads": [
+        "proposal"
+      ],
+      "writes": [
+
+      ],
+      "side_effects": [
+
+      ],
+      "idempotent": true,
+      "timeout": "1m",
+      "retry": {
+        "max_attempts": 1
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "intake",
+      "to": "research"
+    },
+    {
+      "from": "intake",
+      "to": "risk_assessment"
+    },
+    {
+      "from": "research",
+      "to": "synthesize"
+    },
+    {
+      "from": "risk_assessment",
+      "to": "synthesize"
+    },
+    {
+      "from": "synthesize",
+      "to": "review"
+    },
+    {
+      "from": "review",
+      "to": "publish",
+      "when": "review_decision.status == \"approved\""
+    },
+    {
+      "from": "review",
+      "to": "revise",
+      "default": true
+    },
+    {
+      "from": "revise",
+      "to": "review"
+    },
+    {
+      "from": "publish",
+      "to": "done"
+    }
+  ],
+  "parallel_groups": [
+    {
+      "id": "analysis",
+      "branches": [
+        "research",
+        "risk_assessment"
+      ],
+      "join": "synthesize",
+      "on_partial_failure": "fail"
+    }
+  ],
+  "loops": [
+    {
+      "id": "proposal_revision",
+      "nodes": [
+        "review",
+        "revise"
+      ],
+      "exit_when": "review_decision.status == \"approved\"",
+      "max_iterations": 3,
+      "on_exhausted": "fail"
+    }
+  ],
+  "observability": {
+    "capture": [
+      "node_start",
+      "node_end",
+      "edge_selected",
+      "state_delta",
+      "retry",
+      "latency",
+      "error"
+    ],
+    "redact_sensitive_state": true
+  }
+}

--- a/skills/design-workflow-graphs/assets/graph-spec.json
+++ b/skills/design-workflow-graphs/assets/graph-spec.json
@@ -396,6 +396,7 @@
   "parallel_groups": [
     {
       "id": "analysis",
+      "source": "intake",
       "branches": [
         "research",
         "risk_assessment"

--- a/skills/design-workflow-graphs/references/graph-model.md
+++ b/skills/design-workflow-graphs/references/graph-model.md
@@ -12,12 +12,15 @@ Define each shared field with:
 
 - `name`: Stable identifier used by node `reads` and `writes`.
 - `description`: Semantic meaning, not merely its storage type.
+- `type`: Runtime-neutral value shape or schema name.
 - `owner`: Source or component responsible for the field.
+- `writers`: Complete list of nodes authorized to write the field.
 - `merge`: `replace`, `append`, `reduce`, or `reject-conflict`.
 - `sensitive`: Whether traces and logs must redact the value.
 - `persist`: Whether the field must survive pause or retry.
+- `initial`: Whether the field is available before the entry node runs.
 
-Use `replace` for one authoritative current value, `append` for event-like collections, `reduce` when parallel results have an explicit reducer, and `reject-conflict` when multiple writes indicate a design error.
+Use `replace` for one authoritative current value, `append` for event-like collections, `reduce` when parallel results have an explicit reducer, and `reject-conflict` when multiple writes indicate a design error. The declared `writers` must exactly match node `writes`; ownership alone is not write authorization. Every node read must be definitely available on every route into that node, either initially or from preceding writes.
 
 ## Node Contracts
 
@@ -30,13 +33,15 @@ Use one primary responsibility per node. Supported `kind` values in the template
 - `side_effect`: Change an external system.
 - `terminal`: End execution without outgoing edges.
 
-Declare `reads`, `writes`, `side_effects`, `idempotent`, `timeout`, and `retry`. A join also declares `join.strategy` as `all`, `any`, or `quorum`; quorum joins include a positive `join.quorum`.
+Declare `reads`, `writes`, `side_effects`, `idempotent`, `timeout`, `retry`, and `failure`. The failure contract contains a `classification` (`retryable`, `correctable`, `rejectable`, or `terminal`) and an `on_failure` node used after local handling is exhausted. A join also declares `join.strategy` as `all`, `any`, or `quorum`; quorum joins include a positive `join.quorum` no greater than the number of incoming edges.
 
 ## Edge Contracts
 
-Every edge declares `from` and `to`. Add `when` for a guarded route and `default: true` for its fallback. For a router or any conditional branch, provide one default edge and conditions for the remaining edges.
+Every edge declares `from` and `to`. Add `when` for a guarded route and `default: true` for its fallback. A guarded edge also declares `reads`, listing every state field used by its condition. Those fields must be available in the source node's declared reads or writes.
 
-Multiple unconditional outgoing edges represent fan-out. Record the corresponding branches and join in `parallel_groups` so aggregation semantics remain explicit.
+For a router or any conditional branch, provide exactly one default edge and conditions for the remaining edges. Duplicate guards are invalid. When more than one guarded edge leaves a node, assign each guard a distinct positive `priority`. This makes overlap deterministic; the validator cannot prove logical exclusivity for arbitrary runtime expressions, so test guard semantics in the target runtime.
+
+Multiple unconditional outgoing edges represent fan-out. Record the corresponding branches and join in `parallel_groups` so aggregation semantics remain explicit. Parallel branches may share a state field only when its merge policy is `append` or `reduce`; `replace` and `reject-conflict` are rejected because completion order would affect the result. `on_partial_failure` must resolve to a node.
 
 ## Loop Contracts
 
@@ -45,16 +50,22 @@ Declare each cycle under `loops` with:
 - stable `id`
 - complete member-node list
 - measurable `exit_when`
+- explicit `reads` for state referenced by the exit condition
+- `evaluate_after` identifying the loop member after which those reads are available
 - positive `max_iterations` or non-empty `timeout`
-- `on_exhausted` destination or outcome
+- `on_exhausted` destination node outside the loop
 
-The declared member set must cover the actual cyclic component. A retry on one node is not a substitute for a graph-loop budget.
+The declared member set must exactly match an actual cyclic component; do not pad it with upstream, downstream, or terminal nodes. A retry on one node is not a substitute for a graph-loop budget.
 
 ## Side Effects and Recovery
 
 Use `side_effects` for writes, messages, payments, deployments, and other externally visible mutations. A retried side-effect node must be idempotent or protected by an idempotency key. Describe compensation in the design when a completed effect may need reversal.
 
-Persist state required to resume after approvals, timeouts, and process restarts. Do not rely on transient model context for recovery.
+An approval node declares `approval.decision_state`, persistent and definitely available `approval.resume_state`, and resolvable `approval.on_rejected` and `approval.on_expired` routes. Persist state required to resume after approvals, timeouts, and process restarts. Do not rely on transient model context for recovery.
+
+At graph level, declare `recovery.checkpoint_state`, `recovery.on_unhandled_error`, and `recovery.on_cancel`. Recovery destinations must resolve to non-join nodes, and checkpoint fields must persist. Failure, partial-failure, exhaustion, and global recovery transitions participate in reachability and cycle checks; a recovery route that re-enters work therefore needs an explicit bounded loop contract.
+
+Declare machine-readable `evaluation.checks`. Each check has a `scope` (`node`, `route`, `join`, `loop`, or `graph`), a resolvable `target`, and a stable `metric` identifier. The runtime or evaluation harness defines how each metric is computed.
 
 ## Core Invariants
 
@@ -65,5 +76,8 @@ Persist state required to resume after approvals, timeouts, and process restarts
 - Router outcomes are exhaustive and have one fallback.
 - Joins have at least two incoming paths and an explicit strategy.
 - Cycles are declared and bounded.
-- Node state references resolve to declared fields.
+- Node, guard, loop, recovery, and approval state references resolve to declared fields.
+- Every node read is initialized on all normal and recovery paths into the node.
+- State writer declarations exactly match node writes.
+- Parallel writes use order-independent merge semantics.
 - Unsafe side effects are never retried blindly.

--- a/skills/design-workflow-graphs/references/graph-model.md
+++ b/skills/design-workflow-graphs/references/graph-model.md
@@ -37,11 +37,11 @@ Declare `reads`, `writes`, `side_effects`, `idempotent`, `timeout`, `retry`, and
 
 ## Edge Contracts
 
-Every edge declares `from` and `to`. Add `when` for a guarded route and `default: true` for its fallback. A guarded edge also declares `reads`, listing every state field used by its condition. Those fields must be available in the source node's declared reads or writes.
+Every edge declares `from` and `to`. Add `when` for a guarded route and `default: true` for its fallback. A guarded edge also declares `reads`, listing every state field used by its condition. Those fields must be available in the source node's declared reads or writes. Do not duplicate an edge with the same source, destination, normalized guard, and default semantics.
 
 For a router or any conditional branch, provide exactly one default edge and conditions for the remaining edges. Duplicate guards are invalid. When more than one guarded edge leaves a node, assign each guard a distinct positive `priority`. This makes overlap deterministic; the validator cannot prove logical exclusivity for arbitrary runtime expressions, so test guard semantics in the target runtime.
 
-Multiple unconditional outgoing edges represent fan-out. Record the corresponding branches and join in `parallel_groups` so aggregation semantics remain explicit. Parallel branches may share a state field only when its merge policy is `append` or `reduce`; `replace` and `reject-conflict` are rejected because completion order would affect the result. `on_partial_failure` must resolve to a node.
+Multiple unconditional outgoing edges represent fan-out. Record every fan-out in exactly one `parallel_groups` entry with its `source`, exact direct `branches`, `join`, and `on_partial_failure` destination. A parallel group cannot describe guarded or default alternatives. Normal and failure/recovery transitions cannot enter a branch from outside that branch's source-owned region. Every normal branch exit reaches its group join; branch-local failure, exhaustion, and partial-failure exits use the group's `on_partial_failure` destination. Graph-wide cancellation and unhandled-error recovery remain graph-level contracts. The join accepts normal inputs only from its branch region, and each join belongs to one parallel group. Parallel branches may share a state field only when its merge policy is `append` or `reduce`; `replace` and `reject-conflict` are rejected because completion order would affect the result.
 
 ## Loop Contracts
 

--- a/skills/design-workflow-graphs/references/graph-model.md
+++ b/skills/design-workflow-graphs/references/graph-model.md
@@ -1,0 +1,69 @@
+# Graph Model
+
+Use this model when creating or interpreting a Graph Spec.
+
+## Graph Contract
+
+Define the graph identity, goal, entry node, terminal nodes, and global controls. Global controls should include a maximum step count and an elapsed-time budget so unexpected routing cannot run forever.
+
+## State Fields
+
+Define each shared field with:
+
+- `name`: Stable identifier used by node `reads` and `writes`.
+- `description`: Semantic meaning, not merely its storage type.
+- `owner`: Source or component responsible for the field.
+- `merge`: `replace`, `append`, `reduce`, or `reject-conflict`.
+- `sensitive`: Whether traces and logs must redact the value.
+- `persist`: Whether the field must survive pause or retry.
+
+Use `replace` for one authoritative current value, `append` for event-like collections, `reduce` when parallel results have an explicit reducer, and `reject-conflict` when multiple writes indicate a design error.
+
+## Node Contracts
+
+Use one primary responsibility per node. Supported `kind` values in the template are:
+
+- `task`: Perform bounded deterministic or model-assisted work.
+- `router`: Select one downstream route from explicit state.
+- `join`: Wait for and combine parallel branch results.
+- `approval`: Pause for an external decision.
+- `side_effect`: Change an external system.
+- `terminal`: End execution without outgoing edges.
+
+Declare `reads`, `writes`, `side_effects`, `idempotent`, `timeout`, and `retry`. A join also declares `join.strategy` as `all`, `any`, or `quorum`; quorum joins include a positive `join.quorum`.
+
+## Edge Contracts
+
+Every edge declares `from` and `to`. Add `when` for a guarded route and `default: true` for its fallback. For a router or any conditional branch, provide one default edge and conditions for the remaining edges.
+
+Multiple unconditional outgoing edges represent fan-out. Record the corresponding branches and join in `parallel_groups` so aggregation semantics remain explicit.
+
+## Loop Contracts
+
+Declare each cycle under `loops` with:
+
+- stable `id`
+- complete member-node list
+- measurable `exit_when`
+- positive `max_iterations` or non-empty `timeout`
+- `on_exhausted` destination or outcome
+
+The declared member set must cover the actual cyclic component. A retry on one node is not a substitute for a graph-loop budget.
+
+## Side Effects and Recovery
+
+Use `side_effects` for writes, messages, payments, deployments, and other externally visible mutations. A retried side-effect node must be idempotent or protected by an idempotency key. Describe compensation in the design when a completed effect may need reversal.
+
+Persist state required to resume after approvals, timeouts, and process restarts. Do not rely on transient model context for recovery.
+
+## Core Invariants
+
+- The entry and all terminal identifiers resolve to nodes.
+- Every node is reachable from the entry.
+- Every non-terminal node can progress.
+- Terminal nodes have no outgoing edges.
+- Router outcomes are exhaustive and have one fallback.
+- Joins have at least two incoming paths and an explicit strategy.
+- Cycles are declared and bounded.
+- Node state references resolve to declared fields.
+- Unsafe side effects are never retried blindly.

--- a/skills/design-workflow-graphs/references/graph-patterns.md
+++ b/skills/design-workflow-graphs/references/graph-patterns.md
@@ -1,0 +1,81 @@
+# Graph Patterns
+
+Select the smallest pattern that satisfies the control requirements. Combine patterns only when their contracts remain explicit.
+
+## Pipeline
+
+Use a linear sequence for fixed stages with no meaningful branching. Keep it as a pipeline instead of presenting it as a sophisticated graph.
+
+```text
+ingest -> normalize -> validate -> publish
+```
+
+## Conditional Router
+
+Use one router when explicit state selects exactly one downstream path. Define mutually exclusive conditions and one fallback.
+
+```text
+classify -> routine_path
+         -> exception_path
+         -> fallback
+```
+
+## Fan-Out and Fan-In
+
+Use parallel branches for independent work and an explicit join for aggregation. Declare whether the join waits for all, any, or a quorum, and how partial failures affect the result.
+
+```text
+plan -> research -------\
+     -> risk_analysis ---+-> synthesize
+     -> cost_analysis ---/
+```
+
+Avoid parallel branches that write the same state without a reducer or conflict policy.
+
+## Bounded Review Loop
+
+Use a repair loop when output can improve from actionable feedback. Record a progress signal and stop after a measurable budget.
+
+```text
+draft -> review -> accept
+          |
+          v
+        revise -> review
+```
+
+On exhaustion, route to rejection, escalation, or best-effort completion instead of silently continuing.
+
+## Human Approval Gate
+
+Use an approval node before an irreversible or privileged action. Persist the reviewed artifact, decision, actor identity when required, and continuation token.
+
+```text
+prepare -> approval -> execute
+                    -> reject
+```
+
+Treat approval as a pause-and-resume boundary, not as a long-running model call.
+
+## Supervisor and Workers
+
+Use a supervisor when work decomposition must be dynamic. Keep the supervisor responsible for task allocation and termination, not for performing every worker's task.
+
+Bound worker creation, total steps, and re-planning. Prefer static fan-out when the branches are already known.
+
+## Saga and Compensation
+
+Use ordered side-effect nodes with compensating actions when distributed operations cannot share one transaction.
+
+```text
+reserve -> charge -> provision
+   ^          ^          |
+   | compensate in reverse order on failure
+```
+
+Define which failures trigger compensation, whether compensation is retryable, and what happens when compensation itself fails.
+
+## Event-Driven Wait
+
+Use an explicit wait node for external callbacks, timers, or asynchronous completion. Persist correlation identifiers and define timeout and duplicate-event behavior.
+
+Do not model waiting as repeated polling by an LLM unless the runtime provides no better primitive and the polling budget is explicit.

--- a/skills/design-workflow-graphs/references/graph-patterns.md
+++ b/skills/design-workflow-graphs/references/graph-patterns.md
@@ -22,7 +22,7 @@ classify -> routine_path
 
 ## Fan-Out and Fan-In
 
-Use parallel branches for independent work and an explicit join for aggregation. Declare whether the join waits for all, any, or a quorum, and how partial failures affect the result.
+Use parallel branches for independent work and an explicit join for aggregation. In a Graph Spec, bind the group to the fan-out `source` and list its exact direct unconditional targets as `branches`. Declare whether the join waits for all, any, or a quorum, and how partial failures affect the result.
 
 ```text
 plan -> research -------\
@@ -30,7 +30,7 @@ plan -> research -------\
      -> cost_analysis ---/
 ```
 
-Avoid parallel branches that write the same state without a reducer or conflict policy.
+Do not treat guarded or default alternatives as parallel branches. Keep every normal and recovery entry inside its source-owned branch, route normal exits through the group join, and do not reuse the join across groups. Avoid parallel branches that write the same state without a reducer or conflict policy.
 
 ## Bounded Review Loop
 

--- a/skills/design-workflow-graphs/references/review-checklist.md
+++ b/skills/design-workflow-graphs/references/review-checklist.md
@@ -1,0 +1,68 @@
+# Workflow Graph Review Checklist
+
+Use the applicable checks. Report findings by severity and identify the affected graph element.
+
+## Structure
+
+- Entry node exists and is unique.
+- Terminal nodes exist and have no outgoing edges.
+- All nodes are reachable from the entry.
+- Every non-terminal node has an outgoing path.
+- Edges reference valid nodes.
+- Node responsibilities are bounded and distinguishable.
+
+## Routing
+
+- Conditional outcomes are exhaustive.
+- Conditions are mutually exclusive or have explicit priority.
+- Every router has exactly one fallback.
+- Alternative routing is not confused with parallel fan-out.
+- Route decisions depend on explicit state.
+
+## State and Concurrency
+
+- Every read and write references a declared state field.
+- State fields have owners and merge policies.
+- Parallel branches do not silently overwrite shared state.
+- Join completion, timeout, partial failure, and reduction are defined.
+- Sensitive state is excluded or redacted from traces.
+
+## Loops and Termination
+
+- Every cycle is intentional and declared.
+- Each loop has a progress signal and exit condition.
+- Iteration, time, step, or cost budgets are measurable.
+- Budget exhaustion has an explicit route or terminal outcome.
+- Global execution also has a step and time bound.
+
+## Failure and Recovery
+
+- Failures are classified as retryable, correctable, rejectable, or terminal.
+- Retry attempts, delay, and timeout are bounded.
+- Successful work can be checkpointed and resumed.
+- Cancellation and partial completion are defined.
+- Repair paths cannot create an unbounded nested loop.
+
+## Side Effects and Approval
+
+- Side effects are explicit and occur as late as practical.
+- Retried mutations are idempotent or use an idempotency key.
+- Irreversible actions have appropriate validation or approval.
+- Approval inputs and decisions persist across interruption.
+- Compensation order and failure behavior are defined when rollback matters.
+- Node permissions follow least privilege.
+
+## Observability and Evaluation
+
+- Traces record node start, node end, edge selection, state delta, retry, latency, and error.
+- Route selection can be explained from recorded state.
+- Node, routing, join, loop, and end-to-end quality can be evaluated separately.
+- Logs do not expose credentials or sensitive state.
+- Alerts distinguish stalled, exhausted, rejected, and failed executions.
+
+## Severity Guidance
+
+- `critical`: Can cause unauthorized or irreversible external effects.
+- `high`: Can produce unbounded execution, duplicate effects, corrupted shared state, or unrecoverable progress loss.
+- `medium`: Can select the wrong route, mishandle partial failure, or make recovery unreliable.
+- `low`: Reduces clarity, operability, or evaluation quality without directly breaking correctness.

--- a/skills/design-workflow-graphs/references/review-checklist.md
+++ b/skills/design-workflow-graphs/references/review-checklist.md
@@ -17,38 +17,45 @@ Use the applicable checks. Report findings by severity and identify the affected
 - Conditions are mutually exclusive or have explicit priority.
 - Every router has exactly one fallback.
 - Alternative routing is not confused with parallel fan-out.
-- Route decisions depend on explicit state.
+- Guard `reads` declare every state dependency available to the source node.
+- Route decisions depend on explicit state and have runtime boundary tests.
 
 ## State and Concurrency
 
 - Every read and write references a declared state field.
-- State fields have owners and merge policies.
+- State fields have types, owners, complete writer sets, and merge policies.
+- Initial fields are explicit, and reads are available on every arrival path.
 - Parallel branches do not silently overwrite shared state.
+- Concurrent writes use `append` or an explicit `reduce` contract.
 - Join completion, timeout, partial failure, and reduction are defined.
 - Sensitive state is excluded or redacted from traces.
 
 ## Loops and Termination
 
 - Every cycle is intentional and declared.
-- Each loop has a progress signal and exit condition.
+- Declared loop members exactly match the actual cyclic component.
+- Each loop has a progress signal, exit condition, and evaluation point.
 - Iteration, time, step, or cost budgets are measurable.
-- Budget exhaustion has an explicit route or terminal outcome.
+- Budget exhaustion resolves to an explicit node outside the loop.
 - Global execution also has a step and time bound.
 
 ## Failure and Recovery
 
 - Failures are classified as retryable, correctable, rejectable, or terminal.
+- Every non-terminal node has an explicit exhausted-failure destination.
 - Retry attempts, delay, and timeout are bounded.
-- Successful work can be checkpointed and resumed.
-- Cancellation and partial completion are defined.
+- Successful work can be checkpointed in persistent state and resumed.
+- Cancellation, unhandled failure, and partial completion resolve to nodes.
 - Repair paths cannot create an unbounded nested loop.
+- Failure and recovery transitions participate in cycle detection.
 
 ## Side Effects and Approval
 
 - Side effects are explicit and occur as late as practical.
 - Retried mutations are idempotent or use an idempotency key.
 - Irreversible actions have appropriate validation or approval.
-- Approval inputs and decisions persist across interruption.
+- Approval inputs, decisions, and resume state persist across interruption.
+- Approval rejection and expiry have matching outgoing routes.
 - Compensation order and failure behavior are defined when rollback matters.
 - Node permissions follow least privilege.
 
@@ -57,6 +64,7 @@ Use the applicable checks. Report findings by severity and identify the affected
 - Traces record node start, node end, edge selection, state delta, retry, latency, and error.
 - Route selection can be explained from recorded state.
 - Node, routing, join, loop, and end-to-end quality can be evaluated separately.
+- Machine-readable evaluation checks use resolvable targets and stable metric names.
 - Logs do not expose credentials or sensitive state.
 - Alerts distinguish stalled, exhausted, rejected, and failed executions.
 

--- a/skills/design-workflow-graphs/references/review-checklist.md
+++ b/skills/design-workflow-graphs/references/review-checklist.md
@@ -17,6 +17,10 @@ Use the applicable checks. Report findings by severity and identify the affected
 - Conditions are mutually exclusive or have explicit priority.
 - Every router has exactly one fallback.
 - Alternative routing is not confused with parallel fan-out.
+- Every unconditional fan-out has exactly one parallel group with the same source and direct targets.
+- Branch regions have no normal or recovery entries that bypass their source.
+- Normal branch exits reach the group join, and joins are not shared across groups.
+- Branch-local exceptional exits use the group partial-failure route.
 - Guard `reads` declare every state dependency available to the source node.
 - Route decisions depend on explicit state and have runtime boundary tests.
 

--- a/skills/design-workflow-graphs/scripts/validate_graph_spec.py
+++ b/skills/design-workflow-graphs/scripts/validate_graph_spec.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Validate a design-workflow-graphs JSON Graph Spec."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+IDENTIFIER = re.compile(r"^[a-z][a-z0-9_-]*$")
+NODE_KINDS = {"task", "router", "join", "approval", "side_effect", "terminal"}
+MERGE_POLICIES = {"replace", "append", "reduce", "reject-conflict"}
+JOIN_STRATEGIES = {"all", "any", "quorum"}
+REQUIRED_EVENTS = {
+    "node_start",
+    "node_end",
+    "edge_selected",
+    "state_delta",
+    "retry",
+    "latency",
+    "error",
+}
+
+
+def is_mapping(value: Any) -> bool:
+    return isinstance(value, dict)
+
+
+def is_list(value: Any) -> bool:
+    return isinstance(value, list)
+
+
+def validate_document(document: Any) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not is_mapping(document):
+        return ["top level must be a JSON object"], warnings
+
+    if str(document.get("schema_version", "")) != "1":
+        errors.append("schema_version must be \"1\"")
+
+    graph = document.get("graph")
+    if not is_mapping(graph):
+        return errors + ["graph must be a mapping"], warnings
+
+    graph_id = graph.get("id")
+    if not isinstance(graph_id, str) or not IDENTIFIER.fullmatch(graph_id):
+        errors.append("graph.id must be a lowercase identifier")
+    if not isinstance(graph.get("goal"), str) or not graph["goal"].strip():
+        errors.append("graph.goal must be a non-empty string")
+
+    controls = graph.get("controls")
+    if not is_mapping(controls):
+        warnings.append("graph.controls should define max_steps and timeout")
+    else:
+        max_steps = controls.get("max_steps")
+        if not isinstance(max_steps, int) or isinstance(max_steps, bool) or max_steps < 1:
+            errors.append("graph.controls.max_steps must be a positive integer")
+        if not isinstance(controls.get("timeout"), str) or not controls["timeout"].strip():
+            errors.append("graph.controls.timeout must be a non-empty string")
+
+    state_items = document.get("state", [])
+    if not is_list(state_items):
+        errors.append("state must be a list")
+        state_items = []
+
+    state_names: set[str] = set()
+    has_sensitive_state = False
+    for index, field in enumerate(state_items):
+        label = f"state[{index}]"
+        if not is_mapping(field):
+            errors.append(f"{label} must be a mapping")
+            continue
+        name = field.get("name")
+        if not isinstance(name, str) or not IDENTIFIER.fullmatch(name):
+            errors.append(f"{label}.name must be a lowercase identifier")
+            continue
+        if name in state_names:
+            errors.append(f"duplicate state field: {name}")
+        state_names.add(name)
+        if not isinstance(field.get("description"), str) or not field["description"].strip():
+            errors.append(f"state field {name} needs a description")
+        if not isinstance(field.get("owner"), str) or not field["owner"].strip():
+            errors.append(f"state field {name} needs an owner")
+        if field.get("merge") not in MERGE_POLICIES:
+            errors.append(f"state field {name} has an invalid merge policy")
+        for flag in ("sensitive", "persist"):
+            if not isinstance(field.get(flag), bool):
+                errors.append(f"state field {name}.{flag} must be boolean")
+        if field.get("sensitive") is True:
+            has_sensitive_state = True
+
+    node_items = document.get("nodes")
+    if not is_list(node_items) or not node_items:
+        return errors + ["nodes must be a non-empty list"], warnings
+
+    nodes: dict[str, dict[str, Any]] = {}
+    for index, node in enumerate(node_items):
+        label = f"nodes[{index}]"
+        if not is_mapping(node):
+            errors.append(f"{label} must be a mapping")
+            continue
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not IDENTIFIER.fullmatch(node_id):
+            errors.append(f"{label}.id must be a lowercase identifier")
+            continue
+        if node_id in nodes:
+            errors.append(f"duplicate node id: {node_id}")
+        nodes[node_id] = node
+        kind = node.get("kind")
+        if kind not in NODE_KINDS:
+            errors.append(f"node {node_id} has an invalid kind")
+        if not isinstance(node.get("purpose"), str) or not node["purpose"].strip():
+            errors.append(f"node {node_id} needs a purpose")
+        for key in ("reads", "writes", "side_effects"):
+            values = node.get(key)
+            if not is_list(values) or not all(isinstance(item, str) for item in values):
+                errors.append(f"node {node_id}.{key} must be a list of strings")
+        for key in ("reads", "writes"):
+            values = node.get(key, [])
+            if is_list(values):
+                unknown = sorted({item for item in values if item not in state_names})
+                if unknown:
+                    errors.append(f"node {node_id}.{key} references unknown state: {', '.join(unknown)}")
+        if not isinstance(node.get("idempotent"), bool):
+            errors.append(f"node {node_id}.idempotent must be boolean")
+        if not isinstance(node.get("timeout"), str) or not node["timeout"].strip():
+            errors.append(f"node {node_id}.timeout must be a non-empty string")
+        retry = node.get("retry")
+        max_attempts = None
+        if not is_mapping(retry):
+            errors.append(f"node {node_id}.retry must be a mapping")
+        else:
+            max_attempts = retry.get("max_attempts")
+            if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
+                errors.append(f"node {node_id}.retry.max_attempts must be a positive integer")
+        side_effects = node.get("side_effects", [])
+        if side_effects and max_attempts and max_attempts > 1 and node.get("idempotent") is not True:
+            errors.append(f"node {node_id} retries non-idempotent side effects")
+        if kind == "side_effect" and not side_effects:
+            warnings.append(f"side-effect node {node_id} declares no side effects")
+        if kind == "join":
+            join = node.get("join")
+            if not is_mapping(join) or join.get("strategy") not in JOIN_STRATEGIES:
+                errors.append(f"join node {node_id} needs a valid join.strategy")
+            elif join.get("strategy") == "quorum":
+                quorum = join.get("quorum")
+                if not isinstance(quorum, int) or isinstance(quorum, bool) or quorum < 1:
+                    errors.append(f"join node {node_id} needs a positive join.quorum")
+
+    entry = graph.get("entry")
+    if entry not in nodes:
+        errors.append("graph.entry must reference an existing node")
+    terminals_raw = graph.get("terminals")
+    if not is_list(terminals_raw) or not terminals_raw:
+        errors.append("graph.terminals must be a non-empty list")
+        terminals: set[str] = set()
+    else:
+        terminals = {item for item in terminals_raw if isinstance(item, str)}
+        if len(terminals) != len(terminals_raw):
+            errors.append("graph.terminals must contain unique string identifiers")
+        unknown_terminals = sorted(terminals - nodes.keys())
+        if unknown_terminals:
+            errors.append(f"unknown terminal nodes: {', '.join(unknown_terminals)}")
+        for terminal in sorted(terminals & nodes.keys()):
+            if nodes[terminal].get("kind") != "terminal":
+                errors.append(f"terminal node {terminal} must use kind: terminal")
+
+    edge_items = document.get("edges")
+    if not is_list(edge_items):
+        errors.append("edges must be a list")
+        edge_items = []
+
+    outgoing: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    incoming: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for index, edge in enumerate(edge_items):
+        label = f"edges[{index}]"
+        if not is_mapping(edge):
+            errors.append(f"{label} must be a mapping")
+            continue
+        source = edge.get("from")
+        target = edge.get("to")
+        if source not in nodes:
+            errors.append(f"{label}.from references unknown node: {source}")
+        if target not in nodes:
+            errors.append(f"{label}.to references unknown node: {target}")
+        if source in nodes and target in nodes:
+            outgoing[source].append(edge)
+            incoming[target].append(edge)
+            adjacency[source].add(target)
+        if "when" in edge and (not isinstance(edge["when"], str) or not edge["when"].strip()):
+            errors.append(f"{label}.when must be a non-empty string")
+        if "default" in edge and not isinstance(edge["default"], bool):
+            errors.append(f"{label}.default must be boolean")
+        if edge.get("default") is True and "when" in edge:
+            errors.append(f"{label} cannot define both when and default: true")
+
+    for node_id, node in nodes.items():
+        edges = outgoing[node_id]
+        if node_id in terminals:
+            if edges:
+                errors.append(f"terminal node {node_id} must not have outgoing edges")
+        elif not edges:
+            errors.append(f"non-terminal node {node_id} has no outgoing edge")
+
+        guarded = [edge for edge in edges if "when" in edge]
+        defaults = [edge for edge in edges if edge.get("default") is True]
+        requires_routing = node.get("kind") == "router" or bool(guarded) or bool(defaults)
+        if requires_routing:
+            if len(edges) < 2:
+                errors.append(f"routing node {node_id} needs at least two outgoing edges")
+            if len(defaults) != 1:
+                errors.append(f"routing node {node_id} needs exactly one default edge")
+            for edge in edges:
+                if edge not in defaults and "when" not in edge:
+                    errors.append(f"routing edge {node_id} -> {edge.get('to')} needs a condition")
+
+        if node.get("kind") == "join" and len(incoming[node_id]) < 2:
+            errors.append(f"join node {node_id} needs at least two incoming edges")
+
+    if entry in nodes:
+        reachable = walk(entry, adjacency)
+        unreachable = sorted(nodes.keys() - reachable)
+        if unreachable:
+            errors.append(f"unreachable nodes: {', '.join(unreachable)}")
+
+    parallel_items = document.get("parallel_groups", [])
+    if not is_list(parallel_items):
+        errors.append("parallel_groups must be a list")
+        parallel_items = []
+    seen_parallel: set[str] = set()
+    for index, group in enumerate(parallel_items):
+        label = f"parallel_groups[{index}]"
+        if not is_mapping(group):
+            errors.append(f"{label} must be a mapping")
+            continue
+        group_id = group.get("id")
+        if not isinstance(group_id, str) or not IDENTIFIER.fullmatch(group_id):
+            errors.append(f"{label}.id must be a lowercase identifier")
+        elif group_id in seen_parallel:
+            errors.append(f"duplicate parallel group id: {group_id}")
+        else:
+            seen_parallel.add(group_id)
+        branches = group.get("branches")
+        join_id = group.get("join")
+        if not is_list(branches) or len(branches) < 2 or not all(isinstance(item, str) for item in branches):
+            errors.append(f"{label}.branches must contain at least two node ids")
+            branches = []
+        unknown = sorted(set(branches) - nodes.keys())
+        if unknown:
+            errors.append(f"{label} references unknown branches: {', '.join(unknown)}")
+        if join_id not in nodes or nodes.get(join_id, {}).get("kind") != "join":
+            errors.append(f"{label}.join must reference a join node")
+        elif branches:
+            for branch in branches:
+                if branch in nodes and join_id not in walk(branch, adjacency):
+                    errors.append(f"parallel branch {branch} cannot reach join {join_id}")
+        if not isinstance(group.get("on_partial_failure"), str) or not group["on_partial_failure"].strip():
+            warnings.append(f"{label} should define on_partial_failure")
+
+    loop_items = document.get("loops", [])
+    if not is_list(loop_items):
+        errors.append("loops must be a list")
+        loop_items = []
+    declared_loops: list[set[str]] = []
+    seen_loops: set[str] = set()
+    for index, loop in enumerate(loop_items):
+        label = f"loops[{index}]"
+        if not is_mapping(loop):
+            errors.append(f"{label} must be a mapping")
+            continue
+        loop_id = loop.get("id")
+        if not isinstance(loop_id, str) or not IDENTIFIER.fullmatch(loop_id):
+            errors.append(f"{label}.id must be a lowercase identifier")
+        elif loop_id in seen_loops:
+            errors.append(f"duplicate loop id: {loop_id}")
+        else:
+            seen_loops.add(loop_id)
+        members = loop.get("nodes")
+        if not is_list(members) or not members or not all(isinstance(item, str) for item in members):
+            errors.append(f"{label}.nodes must be a non-empty list of node ids")
+            member_set: set[str] = set()
+        else:
+            member_set = set(members)
+            unknown = sorted(member_set - nodes.keys())
+            if unknown:
+                errors.append(f"{label} references unknown nodes: {', '.join(unknown)}")
+            declared_loops.append(member_set)
+        if not isinstance(loop.get("exit_when"), str) or not loop["exit_when"].strip():
+            errors.append(f"{label}.exit_when must be a non-empty string")
+        max_iterations = loop.get("max_iterations")
+        timeout = loop.get("timeout")
+        bounded_iterations = isinstance(max_iterations, int) and not isinstance(max_iterations, bool) and max_iterations > 0
+        bounded_timeout = isinstance(timeout, str) and bool(timeout.strip())
+        if not bounded_iterations and not bounded_timeout:
+            errors.append(f"{label} needs a positive max_iterations or timeout")
+        if not isinstance(loop.get("on_exhausted"), str) or not loop["on_exhausted"].strip():
+            errors.append(f"{label}.on_exhausted must be a non-empty string")
+
+    for component in cyclic_components(nodes.keys(), adjacency):
+        if not any(component <= declared for declared in declared_loops):
+            errors.append(f"undeclared or incompletely declared cycle: {', '.join(sorted(component))}")
+
+    observability = document.get("observability")
+    if not is_mapping(observability):
+        warnings.append("observability should define captured events and redaction")
+    else:
+        capture = observability.get("capture")
+        if not is_list(capture) or not all(isinstance(item, str) for item in capture):
+            errors.append("observability.capture must be a list of strings")
+        else:
+            missing = sorted(REQUIRED_EVENTS - set(capture))
+            if missing:
+                warnings.append(f"observability.capture omits: {', '.join(missing)}")
+        redact_sensitive_state = observability.get("redact_sensitive_state")
+        if not isinstance(redact_sensitive_state, bool):
+            errors.append("observability.redact_sensitive_state must be boolean")
+        elif has_sensitive_state and redact_sensitive_state is not True:
+            errors.append("observability must redact declared sensitive state")
+
+    return errors, warnings
+
+
+def walk(start: str, adjacency: dict[str, set[str]]) -> set[str]:
+    visited: set[str] = set()
+    queue = deque([start])
+    while queue:
+        node = queue.popleft()
+        if node in visited:
+            continue
+        visited.add(node)
+        queue.extend(adjacency.get(node, set()) - visited)
+    return visited
+
+
+def cyclic_components(node_ids: Any, adjacency: dict[str, set[str]]) -> list[set[str]]:
+    index = 0
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    components: list[set[str]] = []
+
+    def visit(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for target in adjacency.get(node, set()):
+            if target not in indices:
+                visit(target)
+                lowlinks[node] = min(lowlinks[node], lowlinks[target])
+            elif target in on_stack:
+                lowlinks[node] = min(lowlinks[node], indices[target])
+
+        if lowlinks[node] == indices[node]:
+            component: set[str] = set()
+            while True:
+                member = stack.pop()
+                on_stack.remove(member)
+                component.add(member)
+                if member == node:
+                    break
+            if len(component) > 1 or node in adjacency.get(node, set()):
+                components.append(component)
+
+    for node in node_ids:
+        if node not in indices:
+            visit(node)
+    return components
+
+
+def run_self_test() -> int:
+    valid = {
+        "schema_version": "1",
+        "graph": {
+            "id": "self_test",
+            "goal": "Exercise validator invariants.",
+            "entry": "start",
+            "terminals": ["done"],
+            "controls": {"max_steps": 2, "timeout": "1m"},
+        },
+        "state": [],
+        "nodes": [
+            {
+                "id": "start",
+                "kind": "task",
+                "purpose": "Start.",
+                "reads": [],
+                "writes": [],
+                "side_effects": [],
+                "idempotent": True,
+                "timeout": "1m",
+                "retry": {"max_attempts": 1},
+            },
+            {
+                "id": "done",
+                "kind": "terminal",
+                "purpose": "Finish.",
+                "reads": [],
+                "writes": [],
+                "side_effects": [],
+                "idempotent": True,
+                "timeout": "1m",
+                "retry": {"max_attempts": 1},
+            },
+        ],
+        "edges": [{"from": "start", "to": "done"}],
+        "parallel_groups": [],
+        "loops": [],
+        "observability": {
+            "capture": sorted(REQUIRED_EVENTS),
+            "redact_sensitive_state": True,
+        },
+    }
+    valid_errors, _ = validate_document(valid)
+    invalid = dict(valid)
+    invalid["edges"] = [{"from": "start", "to": "missing"}]
+    invalid_errors, _ = validate_document(invalid)
+    sensitive = json.loads(json.dumps(valid))
+    sensitive["state"] = [
+        {
+            "name": "secret",
+            "description": "Sensitive test state.",
+            "owner": "start",
+            "merge": "replace",
+            "sensitive": True,
+            "persist": True,
+        }
+    ]
+    sensitive["observability"]["redact_sensitive_state"] = False
+    sensitive_errors, _ = validate_document(sensitive)
+    if valid_errors:
+        print("[ERROR] self-test valid fixture failed:")
+        for message in valid_errors:
+            print(f"  - {message}")
+        return 1
+    if not invalid_errors:
+        print("[ERROR] self-test invalid fixture unexpectedly passed")
+        return 1
+    if "observability must redact declared sensitive state" not in sensitive_errors:
+        print("[ERROR] self-test sensitive-state fixture unexpectedly passed")
+        return 1
+    print("[OK] validator self-test passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("spec", nargs="?", help="Path to a JSON Graph Spec")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as failures")
+    parser.add_argument("--self-test", action="store_true", help="Run built-in validator checks")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+    if not args.spec:
+        parser.error("spec is required unless --self-test is used")
+
+    path = Path(args.spec)
+    try:
+        document = json.loads(path.read_text())
+    except FileNotFoundError:
+        print(f"[ERROR] file not found: {path}", file=sys.stderr)
+        return 2
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"[ERROR] cannot read JSON: {exc}", file=sys.stderr)
+        return 2
+
+    errors, warnings = validate_document(document)
+    for message in warnings:
+        print(f"[WARN] {message}")
+    for message in errors:
+        print(f"[ERROR] {message}")
+
+    if errors or (args.strict and warnings):
+        print(f"[FAIL] {len(errors)} error(s), {len(warnings)} warning(s)")
+        return 1
+    print(f"[OK] Graph Spec is valid with {len(warnings)} warning(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/design-workflow-graphs/scripts/validate_graph_spec.py
+++ b/skills/design-workflow-graphs/scripts/validate_graph_spec.py
@@ -81,18 +81,6 @@ def walk(start: str, adjacency: dict[str, set[str]]) -> set[str]:
     return visited
 
 
-def walk_until(start: str, stop: str, adjacency: dict[str, set[str]]) -> set[str]:
-    visited: set[str] = set()
-    queue = deque([start])
-    while queue:
-        node = queue.popleft()
-        if node == stop or node in visited:
-            continue
-        visited.add(node)
-        queue.extend(adjacency.get(node, set()) - visited - {stop})
-    return visited
-
-
 def cyclic_components(node_ids: Any, adjacency: dict[str, set[str]]) -> list[set[str]]:
     index = 0
     indices: dict[str, int] = {}
@@ -376,6 +364,7 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
     outgoing: dict[str, list[tuple[int, dict[str, Any], list[str]]]] = defaultdict(list)
     incoming: dict[str, list[tuple[int, dict[str, Any], list[str]]]] = defaultdict(list)
     adjacency: dict[str, set[str]] = defaultdict(set)
+    seen_edge_semantics: dict[tuple[str, str, str | None, bool], int] = {}
     for index, edge in enumerate(edge_items):
         label = f"edges[{index}]"
         if not is_mapping(edge):
@@ -427,6 +416,24 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
                 errors.append(f"{label}.priority must be a positive integer")
 
         if valid_source and valid_target:
+            normalized_guard = (
+                " ".join(guard.split())
+                if has_guard and isinstance(guard, str) and guard.strip()
+                else None
+            )
+            if not has_guard or normalized_guard is not None:
+                semantic_key = (
+                    source,
+                    target,
+                    normalized_guard,
+                    edge.get("default") is True,
+                )
+                if semantic_key in seen_edge_semantics:
+                    errors.append(
+                        f"{label} duplicates edges[{seen_edge_semantics[semantic_key]}]"
+                    )
+                else:
+                    seen_edge_semantics[semantic_key] = index
             record = (index, edge, guard_reads)
             validated_edges.append(record)
             outgoing[source].append(record)
@@ -434,6 +441,7 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
             adjacency[source].add(target)
 
     routing_nodes: set[str] = set()
+    fanout_targets: dict[str, set[str]] = {}
     for node_id, node in nodes.items():
         edges = outgoing[node_id]
         if node.get("kind") == "terminal":
@@ -444,6 +452,13 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
 
         guarded = [record for record in edges if "when" in record[1]]
         defaults = [record for record in edges if record[1].get("default") is True]
+        unconditional_targets = {
+            record[1]["to"]
+            for record in edges
+            if "when" not in record[1] and record[1].get("default") is not True
+        }
+        if len(unconditional_targets) >= 2:
+            fanout_targets[node_id] = unconditional_targets
         requires_routing = node.get("kind") == "router" or bool(guarded) or bool(defaults)
         if requires_routing:
             routing_nodes.add(node_id)
@@ -506,14 +521,19 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
                     )
 
     reachability_adjacency: dict[str, set[str]] = defaultdict(set)
+    reverse_adjacency: dict[str, set[str]] = defaultdict(set)
     for source, targets in adjacency.items():
         reachability_adjacency[source].update(targets)
+        for target in targets:
+            reverse_adjacency[target].add(source)
     virtual_transitions: dict[tuple[str, str], bool] = {}
+    virtual_transition_kinds: dict[tuple[str, str], set[str]] = defaultdict(set)
 
     def add_virtual_transition(
         source: str,
         target: str,
         *,
+        kind: str,
         include_source_writes: bool = False,
     ) -> None:
         reachability_adjacency[source].add(target)
@@ -524,6 +544,7 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
             )
         else:
             virtual_transitions[key] = include_source_writes
+        virtual_transition_kinds[key].add(kind)
 
     for node_id, target in failure_targets.items():
         if not isinstance(target, str) or target not in nodes:
@@ -531,13 +552,16 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
         elif nodes[target].get("kind") == "join":
             errors.append(f"node {node_id}.failure.on_failure must not target a join")
         else:
-            add_virtual_transition(node_id, target)
+            add_virtual_transition(node_id, target, kind="node_failure")
 
     parallel_items = document.get("parallel_groups", [])
     if not is_list(parallel_items):
         errors.append("parallel_groups must be a list")
         parallel_items = []
     seen_parallel: set[str] = set()
+    parallel_source_counts: dict[str, int] = defaultdict(int)
+    parallel_join_counts: dict[str, int] = defaultdict(int)
+    parallel_regions: list[tuple[str, dict[str, str], str | None]] = []
     for index, group in enumerate(parallel_items):
         label = f"parallel_groups[{index}]"
         if not is_mapping(group):
@@ -556,22 +580,89 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
         if unknown_branches:
             errors.append(f"{label} references unknown branches: {', '.join(unknown_branches)}")
 
+        source = group.get("source")
+        if not isinstance(source, str) or source not in nodes:
+            errors.append(f"{label}.source must reference a node")
+        else:
+            parallel_source_counts[source] += 1
+            expected_branches = fanout_targets.get(source, set())
+            if not expected_branches:
+                errors.append(f"{label}.source must have at least two unconditional targets")
+            elif set(branches) != expected_branches:
+                errors.append(
+                    f"{label}.branches must exactly match unconditional targets from {source}: "
+                    f"expected {', '.join(sorted(expected_branches))}; "
+                    f"got {', '.join(sorted(set(branches)))}"
+                )
+
         join_id = group.get("join")
         valid_join = isinstance(join_id, str) and join_id in nodes
         if not isinstance(join_id, str):
             errors.append(f"{label}.join must be a node identifier")
         elif not valid_join or nodes[join_id].get("kind") != "join":
             errors.append(f"{label}.join must reference a join node")
+        else:
+            parallel_join_counts[join_id] += 1
 
         branch_paths: dict[str, set[str]] = {}
         if valid_join:
+            can_reach_join = walk(join_id, reverse_adjacency)
             for branch in branches:
                 if branch not in nodes:
                     continue
-                if join_id not in walk(branch, adjacency):
+                branch_reachable = walk(branch, adjacency)
+                if join_id not in branch_reachable:
                     errors.append(f"parallel branch {branch} cannot reach join {join_id}")
                     continue
-                branch_paths[branch] = walk_until(branch, join_id, adjacency)
+                branch_paths[branch] = (branch_reachable & can_reach_join) - {join_id}
+
+        region_nodes: set[str] = set().union(*branch_paths.values()) if branch_paths else set()
+        branch_membership: dict[str, str] = {}
+        for branch, path_nodes in branch_paths.items():
+            for path_node in path_nodes:
+                branch_membership.setdefault(path_node, branch)
+        if isinstance(source, str) and source in nodes:
+            for region_node in sorted(region_nodes):
+                owner_branch = branch_membership.get(region_node)
+                outside_sources = sorted(
+                    {
+                        record[1]["from"]
+                        for record in incoming[region_node]
+                        if record[1]["from"] != source
+                        and branch_membership.get(record[1]["from"]) != owner_branch
+                    }
+                )
+                if outside_sources:
+                    errors.append(
+                        f"{label} branch region node {region_node} has incoming edges "
+                        f"outside source {source}: {', '.join(outside_sources)}"
+                    )
+                outside_targets = sorted(
+                    {
+                        record[1]["to"]
+                        for record in outgoing[region_node]
+                        if record[1]["to"] != join_id
+                        and branch_membership.get(record[1]["to"]) != owner_branch
+                    }
+                )
+                if outside_targets:
+                    errors.append(
+                        f"{label} branch region node {region_node} has normal exits "
+                        f"outside its branch or join {join_id}: {', '.join(outside_targets)}"
+                    )
+        if valid_join:
+            outside_join_sources = sorted(
+                {
+                    record[1]["from"]
+                    for record in incoming[join_id]
+                    if record[1]["from"] not in region_nodes
+                }
+            )
+            if outside_join_sources:
+                errors.append(
+                    f"{label}.join has incoming edges outside its branch region: "
+                    f"{', '.join(outside_join_sources)}"
+                )
 
         valid_branches = sorted(branch_paths)
         for left_index, left in enumerate(valid_branches):
@@ -597,6 +688,7 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
                         )
 
         partial_failure = group.get("on_partial_failure")
+        valid_partial_failure: str | None = None
         if not isinstance(partial_failure, str) or not partial_failure.strip():
             errors.append(f"{label}.on_partial_failure must reference a recovery node")
         elif partial_failure not in nodes:
@@ -604,9 +696,33 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
         elif nodes[partial_failure].get("kind") == "join":
             errors.append(f"{label}.on_partial_failure must not target a join")
         else:
+            valid_partial_failure = partial_failure
             for branch in branches:
                 if branch in nodes:
-                    add_virtual_transition(branch, partial_failure)
+                    add_virtual_transition(
+                        branch,
+                        partial_failure,
+                        kind="partial_failure",
+                    )
+        if branch_membership:
+            parallel_regions.append(
+                (label, branch_membership, valid_partial_failure)
+            )
+
+    for source, targets in sorted(fanout_targets.items()):
+        group_count = parallel_source_counts.get(source, 0)
+        if group_count == 0:
+            errors.append(
+                f"unconditional fan-out from {source} to {', '.join(sorted(targets))} "
+                "needs exactly one parallel group"
+            )
+        elif group_count > 1:
+            errors.append(
+                f"unconditional fan-out from {source} has multiple parallel groups"
+            )
+    for join_id, group_count in sorted(parallel_join_counts.items()):
+        if group_count > 1:
+            errors.append(f"join {join_id} belongs to multiple parallel groups")
 
     loop_items = document.get("loops", [])
     if not is_list(loop_items):
@@ -681,6 +797,7 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
                 add_virtual_transition(
                     member,
                     exhausted,
+                    kind="loop_exhaustion",
                     include_source_writes=True,
                 )
 
@@ -761,7 +878,36 @@ def validate_document(document: Any) -> tuple[list[str], list[str]]:
             else:
                 for source, node in nodes.items():
                     if source != target and node.get("kind") != "terminal":
-                        add_virtual_transition(source, target)
+                        add_virtual_transition(
+                            source,
+                            target,
+                            kind=f"recovery_{key}",
+                        )
+
+    branch_exit_kinds = {"node_failure", "loop_exhaustion", "partial_failure"}
+    for label, branch_membership, partial_failure_target in parallel_regions:
+        for (transition_source, transition_target), _ in virtual_transitions.items():
+            transition_kinds = virtual_transition_kinds[(transition_source, transition_target)]
+            source_branch = branch_membership.get(transition_source)
+            target_branch = branch_membership.get(transition_target)
+            if target_branch is not None and source_branch != target_branch:
+                errors.append(
+                    f"{label} branch region node {transition_target} has a virtual transition "
+                    f"from outside its branch: {transition_source}"
+                )
+            constrained_exit_kinds = sorted(transition_kinds & branch_exit_kinds)
+            if (
+                source_branch is not None
+                and target_branch != source_branch
+                and partial_failure_target is not None
+                and transition_target != partial_failure_target
+                and constrained_exit_kinds
+            ):
+                errors.append(
+                    f"{label} branch {source_branch} exits through "
+                    f"{', '.join(constrained_exit_kinds)} to {transition_target} instead of "
+                    f"on_partial_failure {partial_failure_target}"
+                )
 
     actual_cycles = cyclic_components(nodes.keys(), reachability_adjacency)
     for component in actual_cycles:
@@ -964,6 +1110,31 @@ def run_self_test() -> int:
             print(f"  - warning: {message}")
         return 1
 
+    cancel_valid = json.loads(json.dumps(valid))
+    cancel_valid["graph"]["terminals"].append("cancelled")
+    cancel_valid["nodes"].append(
+        {
+            "id": "cancelled",
+            "kind": "terminal",
+            "purpose": "End a graph-wide cancellation.",
+            "reads": [],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+        }
+    )
+    cancel_valid["recovery"]["on_cancel"] = "cancelled"
+    cancel_errors, cancel_warnings = validate_document(cancel_valid)
+    if cancel_errors or cancel_warnings:
+        print("[ERROR] self-test valid graph cancellation fixture failed:")
+        for message in cancel_errors:
+            print(f"  - error: {message}")
+        for message in cancel_warnings:
+            print(f"  - warning: {message}")
+        return 1
+
     cases: list[tuple[str, dict[str, Any], str]] = []
 
     missing_target = json.loads(json.dumps(valid))
@@ -1003,6 +1174,230 @@ def run_self_test() -> int:
             "on_partial_failure references unknown node",
         )
     )
+
+    undeclared_fanout = json.loads(json.dumps(valid))
+    undeclared_fanout["parallel_groups"] = []
+    cases.append(
+        (
+            "undeclared fan-out",
+            undeclared_fanout,
+            "needs exactly one parallel group",
+        )
+    )
+
+    conditional_parallel = json.loads(json.dumps(valid))
+    intake_edges = [
+        edge for edge in conditional_parallel["edges"] if edge["from"] == "intake"
+    ]
+    intake_edges[0]["when"] = 'request.mode == "research"'
+    intake_edges[0]["reads"] = ["request"]
+    intake_edges[1]["default"] = True
+    cases.append(
+        (
+            "conditional alternatives as parallel",
+            conditional_parallel,
+            "source must have at least two unconditional targets",
+        )
+    )
+
+    missing_parallel_source = json.loads(json.dumps(valid))
+    missing_parallel_source["parallel_groups"][0].pop("source")
+    cases.append(
+        (
+            "missing parallel source",
+            missing_parallel_source,
+            ".source must reference a node",
+        )
+    )
+
+    mismatched_parallel_branches = json.loads(json.dumps(valid))
+    mismatched_parallel_branches["parallel_groups"][0]["branches"] = [
+        "research",
+        "approval",
+    ]
+    cases.append(
+        (
+            "mismatched parallel branches",
+            mismatched_parallel_branches,
+            "branches must exactly match unconditional targets",
+        )
+    )
+
+    duplicate_parallel_source = json.loads(json.dumps(valid))
+    duplicate_group = json.loads(
+        json.dumps(duplicate_parallel_source["parallel_groups"][0])
+    )
+    duplicate_group["id"] = "analysis_duplicate"
+    duplicate_parallel_source["parallel_groups"].append(duplicate_group)
+    cases.append(
+        (
+            "duplicate parallel source",
+            duplicate_parallel_source,
+            "has multiple parallel groups",
+        )
+    )
+    cases.append(
+        (
+            "duplicate parallel join",
+            duplicate_parallel_source,
+            "belongs to multiple parallel groups",
+        )
+    )
+
+    bypassed_parallel_source = json.loads(json.dumps(valid))
+    request_state = next(
+        field for field in bypassed_parallel_source["state"] if field["name"] == "request"
+    )
+    request_state["initial"] = True
+    bypassed_parallel_source["state"].append(
+        {
+            "name": "choice",
+            "description": "Initial route choice for the regression fixture.",
+            "type": "object",
+            "owner": "input",
+            "writers": [],
+            "merge": "replace",
+            "sensitive": False,
+            "persist": True,
+            "initial": True,
+        }
+    )
+    bypassed_parallel_source["nodes"].append(
+        {
+            "id": "choose",
+            "kind": "router",
+            "purpose": "Choose whether to enter or bypass the fan-out source.",
+            "reads": ["choice"],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+            "failure": {"classification": "terminal", "on_failure": "failed"},
+        }
+    )
+    bypassed_parallel_source["graph"]["entry"] = "choose"
+    bypassed_parallel_source["edges"].extend(
+        [
+            {
+                "from": "choose",
+                "to": "intake",
+                "when": 'choice.enter_fanout == true',
+                "reads": ["choice"],
+            },
+            {"from": "choose", "to": "research", "default": True},
+        ]
+    )
+    cases.append(
+        (
+            "bypassed parallel source",
+            bypassed_parallel_source,
+            "incoming edges outside source intake",
+        )
+    )
+
+    failure_bypassed_parallel_source = json.loads(json.dumps(valid))
+    request_state = next(
+        field
+        for field in failure_bypassed_parallel_source["state"]
+        if field["name"] == "request"
+    )
+    request_state["initial"] = True
+    failure_bypassed_parallel_source["nodes"].append(
+        {
+            "id": "preflight",
+            "kind": "task",
+            "purpose": "Run before entering the fan-out source.",
+            "reads": [],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+            "failure": {"classification": "correctable", "on_failure": "research"},
+        }
+    )
+    failure_bypassed_parallel_source["graph"]["entry"] = "preflight"
+    failure_bypassed_parallel_source["edges"].append(
+        {"from": "preflight", "to": "intake"}
+    )
+    cases.append(
+        (
+            "failure bypasses parallel source",
+            failure_bypassed_parallel_source,
+            "virtual transition from outside its branch: preflight",
+        )
+    )
+
+    branch_escapes_join = json.loads(json.dumps(valid))
+    research_node = next(
+        node for node in branch_escapes_join["nodes"] if node["id"] == "research"
+    )
+    research_node["kind"] = "router"
+    research_join_edge = next(
+        edge
+        for edge in branch_escapes_join["edges"]
+        if edge["from"] == "research" and edge["to"] == "synthesize"
+    )
+    research_join_edge["when"] = 'research.status == "complete"'
+    research_join_edge["reads"] = ["research"]
+    branch_escapes_join["nodes"].append(
+        {
+            "id": "skipped",
+            "kind": "terminal",
+            "purpose": "Exit one branch without reaching the group join.",
+            "reads": [],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+        }
+    )
+    branch_escapes_join["graph"]["terminals"].append("skipped")
+    branch_escapes_join["edges"].append(
+        {"from": "research", "to": "skipped", "default": True}
+    )
+    cases.append(
+        (
+            "parallel branch escapes join",
+            branch_escapes_join,
+            "normal exits outside its branch or join synthesize: skipped",
+        )
+    )
+
+    branch_failure_bypasses_group = json.loads(json.dumps(valid))
+    branch_failure_bypasses_group["graph"]["terminals"].append("recovered")
+    branch_failure_bypasses_group["nodes"].append(
+        {
+            "id": "recovered",
+            "kind": "terminal",
+            "purpose": "Exit one failed branch outside the group failure route.",
+            "reads": [],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+        }
+    )
+    research_node = next(
+        node
+        for node in branch_failure_bypasses_group["nodes"]
+        if node["id"] == "research"
+    )
+    research_node["failure"]["on_failure"] = "recovered"
+    cases.append(
+        (
+            "branch failure bypasses group failure",
+            branch_failure_bypasses_group,
+            "instead of on_partial_failure failed",
+        )
+    )
+
+    duplicate_edge = json.loads(json.dumps(valid))
+    duplicate_edge["edges"].append(json.loads(json.dumps(duplicate_edge["edges"][0])))
+    cases.append(("duplicate edge", duplicate_edge, "duplicates edges[0]"))
 
     conflict = json.loads(json.dumps(valid))
     research = next(node for node in conflict["nodes"] if node["id"] == "research")

--- a/skills/design-workflow-graphs/scripts/validate_graph_spec.py
+++ b/skills/design-workflow-graphs/scripts/validate_graph_spec.py
@@ -11,10 +11,15 @@ from collections import defaultdict, deque
 from pathlib import Path
 from typing import Any
 
+
 IDENTIFIER = re.compile(r"^[a-z][a-z0-9_-]*$")
+GUARD_STATE_REF = re.compile(r"\b([a-z][a-z0-9_-]*)\.")
 NODE_KINDS = {"task", "router", "join", "approval", "side_effect", "terminal"}
 MERGE_POLICIES = {"replace", "append", "reduce", "reject-conflict"}
+PARALLEL_SAFE_MERGES = {"append", "reduce"}
 JOIN_STRATEGIES = {"all", "any", "quorum"}
+EVALUATION_SCOPES = {"node", "route", "join", "loop", "graph"}
+FAILURE_CLASSES = {"retryable", "correctable", "rejectable", "terminal"}
 REQUIRED_EVENTS = {
     "node_start",
     "node_end",
@@ -34,297 +39,34 @@ def is_list(value: Any) -> bool:
     return isinstance(value, list)
 
 
-def validate_document(document: Any) -> tuple[list[str], list[str]]:
-    errors: list[str] = []
-    warnings: list[str] = []
+def string_list(
+    value: Any,
+    label: str,
+    errors: list[str],
+    *,
+    min_items: int = 0,
+) -> list[str]:
+    if not is_list(value):
+        errors.append(f"{label} must be a list of strings")
+        return []
 
-    if not is_mapping(document):
-        return ["top level must be a JSON object"], warnings
-
-    if str(document.get("schema_version", "")) != "1":
-        errors.append("schema_version must be \"1\"")
-
-    graph = document.get("graph")
-    if not is_mapping(graph):
-        return errors + ["graph must be a mapping"], warnings
-
-    graph_id = graph.get("id")
-    if not isinstance(graph_id, str) or not IDENTIFIER.fullmatch(graph_id):
-        errors.append("graph.id must be a lowercase identifier")
-    if not isinstance(graph.get("goal"), str) or not graph["goal"].strip():
-        errors.append("graph.goal must be a non-empty string")
-
-    controls = graph.get("controls")
-    if not is_mapping(controls):
-        warnings.append("graph.controls should define max_steps and timeout")
-    else:
-        max_steps = controls.get("max_steps")
-        if not isinstance(max_steps, int) or isinstance(max_steps, bool) or max_steps < 1:
-            errors.append("graph.controls.max_steps must be a positive integer")
-        if not isinstance(controls.get("timeout"), str) or not controls["timeout"].strip():
-            errors.append("graph.controls.timeout must be a non-empty string")
-
-    state_items = document.get("state", [])
-    if not is_list(state_items):
-        errors.append("state must be a list")
-        state_items = []
-
-    state_names: set[str] = set()
-    has_sensitive_state = False
-    for index, field in enumerate(state_items):
-        label = f"state[{index}]"
-        if not is_mapping(field):
-            errors.append(f"{label} must be a mapping")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{label}[{index}] must be a non-empty string")
             continue
-        name = field.get("name")
-        if not isinstance(name, str) or not IDENTIFIER.fullmatch(name):
-            errors.append(f"{label}.name must be a lowercase identifier")
-            continue
-        if name in state_names:
-            errors.append(f"duplicate state field: {name}")
-        state_names.add(name)
-        if not isinstance(field.get("description"), str) or not field["description"].strip():
-            errors.append(f"state field {name} needs a description")
-        if not isinstance(field.get("owner"), str) or not field["owner"].strip():
-            errors.append(f"state field {name} needs an owner")
-        if field.get("merge") not in MERGE_POLICIES:
-            errors.append(f"state field {name} has an invalid merge policy")
-        for flag in ("sensitive", "persist"):
-            if not isinstance(field.get(flag), bool):
-                errors.append(f"state field {name}.{flag} must be boolean")
-        if field.get("sensitive") is True:
-            has_sensitive_state = True
+        result.append(item)
 
-    node_items = document.get("nodes")
-    if not is_list(node_items) or not node_items:
-        return errors + ["nodes must be a non-empty list"], warnings
+    if len(result) < min_items:
+        errors.append(f"{label} must contain at least {min_items} item(s)")
+    return result
 
-    nodes: dict[str, dict[str, Any]] = {}
-    for index, node in enumerate(node_items):
-        label = f"nodes[{index}]"
-        if not is_mapping(node):
-            errors.append(f"{label} must be a mapping")
-            continue
-        node_id = node.get("id")
-        if not isinstance(node_id, str) or not IDENTIFIER.fullmatch(node_id):
-            errors.append(f"{label}.id must be a lowercase identifier")
-            continue
-        if node_id in nodes:
-            errors.append(f"duplicate node id: {node_id}")
-        nodes[node_id] = node
-        kind = node.get("kind")
-        if kind not in NODE_KINDS:
-            errors.append(f"node {node_id} has an invalid kind")
-        if not isinstance(node.get("purpose"), str) or not node["purpose"].strip():
-            errors.append(f"node {node_id} needs a purpose")
-        for key in ("reads", "writes", "side_effects"):
-            values = node.get(key)
-            if not is_list(values) or not all(isinstance(item, str) for item in values):
-                errors.append(f"node {node_id}.{key} must be a list of strings")
-        for key in ("reads", "writes"):
-            values = node.get(key, [])
-            if is_list(values):
-                unknown = sorted({item for item in values if item not in state_names})
-                if unknown:
-                    errors.append(f"node {node_id}.{key} references unknown state: {', '.join(unknown)}")
-        if not isinstance(node.get("idempotent"), bool):
-            errors.append(f"node {node_id}.idempotent must be boolean")
-        if not isinstance(node.get("timeout"), str) or not node["timeout"].strip():
-            errors.append(f"node {node_id}.timeout must be a non-empty string")
-        retry = node.get("retry")
-        max_attempts = None
-        if not is_mapping(retry):
-            errors.append(f"node {node_id}.retry must be a mapping")
-        else:
-            max_attempts = retry.get("max_attempts")
-            if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
-                errors.append(f"node {node_id}.retry.max_attempts must be a positive integer")
-        side_effects = node.get("side_effects", [])
-        if side_effects and max_attempts and max_attempts > 1 and node.get("idempotent") is not True:
-            errors.append(f"node {node_id} retries non-idempotent side effects")
-        if kind == "side_effect" and not side_effects:
-            warnings.append(f"side-effect node {node_id} declares no side effects")
-        if kind == "join":
-            join = node.get("join")
-            if not is_mapping(join) or join.get("strategy") not in JOIN_STRATEGIES:
-                errors.append(f"join node {node_id} needs a valid join.strategy")
-            elif join.get("strategy") == "quorum":
-                quorum = join.get("quorum")
-                if not isinstance(quorum, int) or isinstance(quorum, bool) or quorum < 1:
-                    errors.append(f"join node {node_id} needs a positive join.quorum")
 
-    entry = graph.get("entry")
-    if entry not in nodes:
-        errors.append("graph.entry must reference an existing node")
-    terminals_raw = graph.get("terminals")
-    if not is_list(terminals_raw) or not terminals_raw:
-        errors.append("graph.terminals must be a non-empty list")
-        terminals: set[str] = set()
-    else:
-        terminals = {item for item in terminals_raw if isinstance(item, str)}
-        if len(terminals) != len(terminals_raw):
-            errors.append("graph.terminals must contain unique string identifiers")
-        unknown_terminals = sorted(terminals - nodes.keys())
-        if unknown_terminals:
-            errors.append(f"unknown terminal nodes: {', '.join(unknown_terminals)}")
-        for terminal in sorted(terminals & nodes.keys()):
-            if nodes[terminal].get("kind") != "terminal":
-                errors.append(f"terminal node {terminal} must use kind: terminal")
-
-    edge_items = document.get("edges")
-    if not is_list(edge_items):
-        errors.append("edges must be a list")
-        edge_items = []
-
-    outgoing: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    incoming: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    adjacency: dict[str, set[str]] = defaultdict(set)
-    for index, edge in enumerate(edge_items):
-        label = f"edges[{index}]"
-        if not is_mapping(edge):
-            errors.append(f"{label} must be a mapping")
-            continue
-        source = edge.get("from")
-        target = edge.get("to")
-        if source not in nodes:
-            errors.append(f"{label}.from references unknown node: {source}")
-        if target not in nodes:
-            errors.append(f"{label}.to references unknown node: {target}")
-        if source in nodes and target in nodes:
-            outgoing[source].append(edge)
-            incoming[target].append(edge)
-            adjacency[source].add(target)
-        if "when" in edge and (not isinstance(edge["when"], str) or not edge["when"].strip()):
-            errors.append(f"{label}.when must be a non-empty string")
-        if "default" in edge and not isinstance(edge["default"], bool):
-            errors.append(f"{label}.default must be boolean")
-        if edge.get("default") is True and "when" in edge:
-            errors.append(f"{label} cannot define both when and default: true")
-
-    for node_id, node in nodes.items():
-        edges = outgoing[node_id]
-        if node_id in terminals:
-            if edges:
-                errors.append(f"terminal node {node_id} must not have outgoing edges")
-        elif not edges:
-            errors.append(f"non-terminal node {node_id} has no outgoing edge")
-
-        guarded = [edge for edge in edges if "when" in edge]
-        defaults = [edge for edge in edges if edge.get("default") is True]
-        requires_routing = node.get("kind") == "router" or bool(guarded) or bool(defaults)
-        if requires_routing:
-            if len(edges) < 2:
-                errors.append(f"routing node {node_id} needs at least two outgoing edges")
-            if len(defaults) != 1:
-                errors.append(f"routing node {node_id} needs exactly one default edge")
-            for edge in edges:
-                if edge not in defaults and "when" not in edge:
-                    errors.append(f"routing edge {node_id} -> {edge.get('to')} needs a condition")
-
-        if node.get("kind") == "join" and len(incoming[node_id]) < 2:
-            errors.append(f"join node {node_id} needs at least two incoming edges")
-
-    if entry in nodes:
-        reachable = walk(entry, adjacency)
-        unreachable = sorted(nodes.keys() - reachable)
-        if unreachable:
-            errors.append(f"unreachable nodes: {', '.join(unreachable)}")
-
-    parallel_items = document.get("parallel_groups", [])
-    if not is_list(parallel_items):
-        errors.append("parallel_groups must be a list")
-        parallel_items = []
-    seen_parallel: set[str] = set()
-    for index, group in enumerate(parallel_items):
-        label = f"parallel_groups[{index}]"
-        if not is_mapping(group):
-            errors.append(f"{label} must be a mapping")
-            continue
-        group_id = group.get("id")
-        if not isinstance(group_id, str) or not IDENTIFIER.fullmatch(group_id):
-            errors.append(f"{label}.id must be a lowercase identifier")
-        elif group_id in seen_parallel:
-            errors.append(f"duplicate parallel group id: {group_id}")
-        else:
-            seen_parallel.add(group_id)
-        branches = group.get("branches")
-        join_id = group.get("join")
-        if not is_list(branches) or len(branches) < 2 or not all(isinstance(item, str) for item in branches):
-            errors.append(f"{label}.branches must contain at least two node ids")
-            branches = []
-        unknown = sorted(set(branches) - nodes.keys())
-        if unknown:
-            errors.append(f"{label} references unknown branches: {', '.join(unknown)}")
-        if join_id not in nodes or nodes.get(join_id, {}).get("kind") != "join":
-            errors.append(f"{label}.join must reference a join node")
-        elif branches:
-            for branch in branches:
-                if branch in nodes and join_id not in walk(branch, adjacency):
-                    errors.append(f"parallel branch {branch} cannot reach join {join_id}")
-        if not isinstance(group.get("on_partial_failure"), str) or not group["on_partial_failure"].strip():
-            warnings.append(f"{label} should define on_partial_failure")
-
-    loop_items = document.get("loops", [])
-    if not is_list(loop_items):
-        errors.append("loops must be a list")
-        loop_items = []
-    declared_loops: list[set[str]] = []
-    seen_loops: set[str] = set()
-    for index, loop in enumerate(loop_items):
-        label = f"loops[{index}]"
-        if not is_mapping(loop):
-            errors.append(f"{label} must be a mapping")
-            continue
-        loop_id = loop.get("id")
-        if not isinstance(loop_id, str) or not IDENTIFIER.fullmatch(loop_id):
-            errors.append(f"{label}.id must be a lowercase identifier")
-        elif loop_id in seen_loops:
-            errors.append(f"duplicate loop id: {loop_id}")
-        else:
-            seen_loops.add(loop_id)
-        members = loop.get("nodes")
-        if not is_list(members) or not members or not all(isinstance(item, str) for item in members):
-            errors.append(f"{label}.nodes must be a non-empty list of node ids")
-            member_set: set[str] = set()
-        else:
-            member_set = set(members)
-            unknown = sorted(member_set - nodes.keys())
-            if unknown:
-                errors.append(f"{label} references unknown nodes: {', '.join(unknown)}")
-            declared_loops.append(member_set)
-        if not isinstance(loop.get("exit_when"), str) or not loop["exit_when"].strip():
-            errors.append(f"{label}.exit_when must be a non-empty string")
-        max_iterations = loop.get("max_iterations")
-        timeout = loop.get("timeout")
-        bounded_iterations = isinstance(max_iterations, int) and not isinstance(max_iterations, bool) and max_iterations > 0
-        bounded_timeout = isinstance(timeout, str) and bool(timeout.strip())
-        if not bounded_iterations and not bounded_timeout:
-            errors.append(f"{label} needs a positive max_iterations or timeout")
-        if not isinstance(loop.get("on_exhausted"), str) or not loop["on_exhausted"].strip():
-            errors.append(f"{label}.on_exhausted must be a non-empty string")
-
-    for component in cyclic_components(nodes.keys(), adjacency):
-        if not any(component <= declared for declared in declared_loops):
-            errors.append(f"undeclared or incompletely declared cycle: {', '.join(sorted(component))}")
-
-    observability = document.get("observability")
-    if not is_mapping(observability):
-        warnings.append("observability should define captured events and redaction")
-    else:
-        capture = observability.get("capture")
-        if not is_list(capture) or not all(isinstance(item, str) for item in capture):
-            errors.append("observability.capture must be a list of strings")
-        else:
-            missing = sorted(REQUIRED_EVENTS - set(capture))
-            if missing:
-                warnings.append(f"observability.capture omits: {', '.join(missing)}")
-        redact_sensitive_state = observability.get("redact_sensitive_state")
-        if not isinstance(redact_sensitive_state, bool):
-            errors.append("observability.redact_sensitive_state must be boolean")
-        elif has_sensitive_state and redact_sensitive_state is not True:
-            errors.append("observability must redact declared sensitive state")
-
-    return errors, warnings
+def validate_identifier(value: Any, label: str, errors: list[str]) -> str | None:
+    if not isinstance(value, str) or not IDENTIFIER.fullmatch(value):
+        errors.append(f"{label} must be a lowercase identifier")
+        return None
+    return value
 
 
 def walk(start: str, adjacency: dict[str, set[str]]) -> set[str]:
@@ -336,6 +78,18 @@ def walk(start: str, adjacency: dict[str, set[str]]) -> set[str]:
             continue
         visited.add(node)
         queue.extend(adjacency.get(node, set()) - visited)
+    return visited
+
+
+def walk_until(start: str, stop: str, adjacency: dict[str, set[str]]) -> set[str]:
+    visited: set[str] = set()
+    queue = deque([start])
+    while queue:
+        node = queue.popleft()
+        if node == stop or node in visited:
+            continue
+        visited.add(node)
+        queue.extend(adjacency.get(node, set()) - visited - {stop})
     return visited
 
 
@@ -379,78 +133,1022 @@ def cyclic_components(node_ids: Any, adjacency: dict[str, set[str]]) -> list[set
     return components
 
 
-def run_self_test() -> int:
-    valid = {
-        "schema_version": "1",
-        "graph": {
-            "id": "self_test",
-            "goal": "Exercise validator invariants.",
-            "entry": "start",
-            "terminals": ["done"],
-            "controls": {"max_steps": 2, "timeout": "1m"},
-        },
-        "state": [],
-        "nodes": [
-            {
-                "id": "start",
-                "kind": "task",
-                "purpose": "Start.",
-                "reads": [],
-                "writes": [],
-                "side_effects": [],
-                "idempotent": True,
-                "timeout": "1m",
-                "retry": {"max_attempts": 1},
-            },
-            {
-                "id": "done",
-                "kind": "terminal",
-                "purpose": "Finish.",
-                "reads": [],
-                "writes": [],
-                "side_effects": [],
-                "idempotent": True,
-                "timeout": "1m",
-                "retry": {"max_attempts": 1},
-            },
-        ],
-        "edges": [{"from": "start", "to": "done"}],
-        "parallel_groups": [],
-        "loops": [],
-        "observability": {
-            "capture": sorted(REQUIRED_EVENTS),
-            "redact_sensitive_state": True,
-        },
-    }
-    valid_errors, _ = validate_document(valid)
-    invalid = dict(valid)
-    invalid["edges"] = [{"from": "start", "to": "missing"}]
-    invalid_errors, _ = validate_document(invalid)
-    sensitive = json.loads(json.dumps(valid))
-    sensitive["state"] = [
-        {
-            "name": "secret",
-            "description": "Sensitive test state.",
-            "owner": "start",
-            "merge": "replace",
-            "sensitive": True,
-            "persist": True,
+def validate_document(document: Any) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not is_mapping(document):
+        return ["top level must be a JSON object"], warnings
+
+    if str(document.get("schema_version", "")) != "1":
+        errors.append('schema_version must be "1"')
+
+    graph = document.get("graph")
+    if not is_mapping(graph):
+        return errors + ["graph must be a mapping"], warnings
+
+    graph_id = validate_identifier(graph.get("id"), "graph.id", errors)
+    if not isinstance(graph.get("goal"), str) or not graph["goal"].strip():
+        errors.append("graph.goal must be a non-empty string")
+
+    controls = graph.get("controls")
+    if not is_mapping(controls):
+        warnings.append("graph.controls should define max_steps and timeout")
+    else:
+        max_steps = controls.get("max_steps")
+        if not isinstance(max_steps, int) or isinstance(max_steps, bool) or max_steps < 1:
+            errors.append("graph.controls.max_steps must be a positive integer")
+        if not isinstance(controls.get("timeout"), str) or not controls["timeout"].strip():
+            errors.append("graph.controls.timeout must be a non-empty string")
+
+    state_items = document.get("state", [])
+    if not is_list(state_items):
+        errors.append("state must be a list")
+        state_items = []
+
+    state_fields: dict[str, dict[str, Any]] = {}
+    declared_state_writers: dict[str, set[str]] = {}
+    initial_state: set[str] = set()
+    has_sensitive_state = False
+    for index, field in enumerate(state_items):
+        label = f"state[{index}]"
+        if not is_mapping(field):
+            errors.append(f"{label} must be a mapping")
+            continue
+        name = validate_identifier(field.get("name"), f"{label}.name", errors)
+        if name is None:
+            continue
+        if name in state_fields:
+            errors.append(f"duplicate state field: {name}")
+            continue
+        state_fields[name] = field
+        if not isinstance(field.get("description"), str) or not field["description"].strip():
+            errors.append(f"state field {name} needs a description")
+        if not isinstance(field.get("type"), str) or not field["type"].strip():
+            errors.append(f"state field {name} needs a non-empty type")
+        if not isinstance(field.get("owner"), str) or not field["owner"].strip():
+            errors.append(f"state field {name} needs an owner")
+        merge = field.get("merge")
+        if not isinstance(merge, str) or merge not in MERGE_POLICIES:
+            errors.append(f"state field {name} has an invalid merge policy")
+        if merge == "reduce" and (
+            not isinstance(field.get("reducer"), str) or not field["reducer"].strip()
+        ):
+            errors.append(f"state field {name} with merge reduce needs a reducer")
+        writers = string_list(field.get("writers"), f"state field {name}.writers", errors)
+        valid_writers: set[str] = set()
+        for writer in writers:
+            if IDENTIFIER.fullmatch(writer):
+                valid_writers.add(writer)
+            else:
+                errors.append(f"state field {name}.writers contains invalid node id: {writer}")
+        if len(valid_writers) != len(writers):
+            errors.append(f"state field {name}.writers must contain unique node ids")
+        declared_state_writers[name] = valid_writers
+        for flag in ("sensitive", "persist"):
+            if not isinstance(field.get(flag), bool):
+                errors.append(f"state field {name}.{flag} must be boolean")
+        if not isinstance(field.get("initial"), bool):
+            errors.append(f"state field {name}.initial must be boolean")
+        elif field["initial"]:
+            initial_state.add(name)
+        if field.get("sensitive") is True:
+            has_sensitive_state = True
+
+    state_names = set(state_fields)
+    node_items = document.get("nodes")
+    if not is_list(node_items) or not node_items:
+        return errors + ["nodes must be a non-empty list"], warnings
+
+    nodes: dict[str, dict[str, Any]] = {}
+    node_reads: dict[str, set[str]] = {}
+    node_writes: dict[str, set[str]] = {}
+    approval_nodes: list[str] = []
+    failure_targets: dict[str, Any] = {}
+    for index, node in enumerate(node_items):
+        label = f"nodes[{index}]"
+        if not is_mapping(node):
+            errors.append(f"{label} must be a mapping")
+            continue
+        node_id = validate_identifier(node.get("id"), f"{label}.id", errors)
+        if node_id is None:
+            continue
+        if node_id in nodes:
+            errors.append(f"duplicate node id: {node_id}")
+            continue
+        nodes[node_id] = node
+        kind = node.get("kind")
+        if not isinstance(kind, str) or kind not in NODE_KINDS:
+            errors.append(f"node {node_id} has an invalid kind")
+        if not isinstance(node.get("purpose"), str) or not node["purpose"].strip():
+            errors.append(f"node {node_id} needs a purpose")
+
+        reads = string_list(node.get("reads"), f"node {node_id}.reads", errors)
+        writes = string_list(node.get("writes"), f"node {node_id}.writes", errors)
+        side_effects = string_list(
+            node.get("side_effects"), f"node {node_id}.side_effects", errors
+        )
+        node_reads[node_id] = set(reads)
+        node_writes[node_id] = set(writes)
+        for key, values in (("reads", reads), ("writes", writes)):
+            unknown = sorted(set(values) - state_names)
+            if unknown:
+                errors.append(
+                    f"node {node_id}.{key} references unknown state: {', '.join(unknown)}"
+                )
+
+        if not isinstance(node.get("idempotent"), bool):
+            errors.append(f"node {node_id}.idempotent must be boolean")
+        if not isinstance(node.get("timeout"), str) or not node["timeout"].strip():
+            errors.append(f"node {node_id}.timeout must be a non-empty string")
+        retry = node.get("retry")
+        max_attempts = None
+        if not is_mapping(retry):
+            errors.append(f"node {node_id}.retry must be a mapping")
+        else:
+            max_attempts = retry.get("max_attempts")
+            if (
+                not isinstance(max_attempts, int)
+                or isinstance(max_attempts, bool)
+                or max_attempts < 1
+            ):
+                errors.append(f"node {node_id}.retry.max_attempts must be a positive integer")
+        if side_effects and max_attempts and max_attempts > 1 and node.get("idempotent") is not True:
+            errors.append(f"node {node_id} retries non-idempotent side effects")
+        if kind == "side_effect" and not side_effects:
+            warnings.append(f"side-effect node {node_id} declares no side effects")
+
+        if kind == "join":
+            join = node.get("join")
+            if not is_mapping(join):
+                errors.append(f"join node {node_id} needs a valid join mapping")
+            else:
+                strategy = join.get("strategy")
+                if not isinstance(strategy, str) or strategy not in JOIN_STRATEGIES:
+                    errors.append(f"join node {node_id} needs a valid join.strategy")
+                elif strategy == "quorum":
+                    quorum = join.get("quorum")
+                    if (
+                        not isinstance(quorum, int)
+                        or isinstance(quorum, bool)
+                        or quorum < 1
+                    ):
+                        errors.append(f"join node {node_id} needs a positive join.quorum")
+
+        if kind == "approval":
+            approval_nodes.append(node_id)
+
+        if kind == "terminal":
+            if "failure" in node:
+                errors.append(f"terminal node {node_id} must not define failure handling")
+        else:
+            failure = node.get("failure")
+            if not is_mapping(failure):
+                errors.append(f"node {node_id} needs a failure mapping")
+            else:
+                classification = failure.get("classification")
+                if not isinstance(classification, str) or classification not in FAILURE_CLASSES:
+                    errors.append(f"node {node_id}.failure.classification is invalid")
+                failure_targets[node_id] = failure.get("on_failure")
+
+    actual_state_writers: dict[str, set[str]] = defaultdict(set)
+    for node_id, writes in node_writes.items():
+        for state_name in writes & state_names:
+            actual_state_writers[state_name].add(node_id)
+    for state_name in sorted(state_names):
+        declared = declared_state_writers.get(state_name, set())
+        unknown_writers = sorted(declared - nodes.keys())
+        if unknown_writers:
+            errors.append(
+                f"state field {state_name}.writers references unknown nodes: "
+                f"{', '.join(unknown_writers)}"
+            )
+        actual = actual_state_writers.get(state_name, set())
+        missing = sorted(actual - declared)
+        extra = sorted((declared & nodes.keys()) - actual)
+        if missing:
+            errors.append(
+                f"state field {state_name}.writers omits actual writers: {', '.join(missing)}"
+            )
+        if extra:
+            errors.append(
+                f"state field {state_name}.writers declares nodes that do not write it: "
+                f"{', '.join(extra)}"
+            )
+
+    entry = graph.get("entry")
+    if not isinstance(entry, str) or entry not in nodes:
+        errors.append("graph.entry must reference an existing node")
+        entry = None
+
+    terminals_raw = graph.get("terminals")
+    if not is_list(terminals_raw) or not terminals_raw:
+        errors.append("graph.terminals must be a non-empty list")
+        terminals: set[str] = set()
+    else:
+        terminal_values = string_list(terminals_raw, "graph.terminals", errors, min_items=1)
+        terminals = set(terminal_values)
+        if len(terminals) != len(terminal_values):
+            errors.append("graph.terminals must contain unique node ids")
+        unknown_terminals = sorted(terminals - nodes.keys())
+        if unknown_terminals:
+            errors.append(f"unknown terminal nodes: {', '.join(unknown_terminals)}")
+
+    kind_terminals = {node_id for node_id, node in nodes.items() if node.get("kind") == "terminal"}
+    unlisted_kind_terminals = sorted(kind_terminals - terminals)
+    non_terminal_kinds = sorted((terminals & nodes.keys()) - kind_terminals)
+    if unlisted_kind_terminals:
+        errors.append(
+            "kind terminal nodes missing from graph.terminals: "
+            + ", ".join(unlisted_kind_terminals)
+        )
+    if non_terminal_kinds:
+        errors.append(
+            "graph.terminals nodes must use kind terminal: " + ", ".join(non_terminal_kinds)
+        )
+
+    edge_items = document.get("edges")
+    if not is_list(edge_items):
+        errors.append("edges must be a list")
+        edge_items = []
+
+    validated_edges: list[tuple[int, dict[str, Any], list[str]]] = []
+    outgoing: dict[str, list[tuple[int, dict[str, Any], list[str]]]] = defaultdict(list)
+    incoming: dict[str, list[tuple[int, dict[str, Any], list[str]]]] = defaultdict(list)
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for index, edge in enumerate(edge_items):
+        label = f"edges[{index}]"
+        if not is_mapping(edge):
+            errors.append(f"{label} must be a mapping")
+            continue
+        source = edge.get("from")
+        target = edge.get("to")
+        valid_source = isinstance(source, str) and source in nodes
+        valid_target = isinstance(target, str) and target in nodes
+        if not isinstance(source, str):
+            errors.append(f"{label}.from must be a node identifier")
+        elif not valid_source:
+            errors.append(f"{label}.from references unknown node: {source}")
+        if not isinstance(target, str):
+            errors.append(f"{label}.to must be a node identifier")
+        elif not valid_target:
+            errors.append(f"{label}.to references unknown node: {target}")
+
+        has_guard = "when" in edge
+        guard = edge.get("when")
+        if has_guard and (not isinstance(guard, str) or not guard.strip()):
+            errors.append(f"{label}.when must be a non-empty string")
+        if "default" in edge and not isinstance(edge["default"], bool):
+            errors.append(f"{label}.default must be boolean")
+        if edge.get("default") is True and has_guard:
+            errors.append(f"{label} cannot define both when and default: true")
+
+        guard_reads: list[str] = []
+        if has_guard:
+            guard_reads = string_list(edge.get("reads"), f"{label}.reads", errors, min_items=1)
+            unknown_reads = sorted(set(guard_reads) - state_names)
+            if unknown_reads:
+                errors.append(f"{label}.reads references unknown state: {', '.join(unknown_reads)}")
+            if isinstance(guard, str):
+                implicit_refs = set(GUARD_STATE_REF.findall(guard))
+                omitted_refs = sorted(implicit_refs - set(guard_reads))
+                if omitted_refs:
+                    errors.append(
+                        f"{label}.reads omits state referenced by guard: {', '.join(omitted_refs)}"
+                    )
+        elif "reads" in edge:
+            unexpected_reads = string_list(edge.get("reads"), f"{label}.reads", errors)
+            if unexpected_reads:
+                errors.append(f"{label}.reads is only valid with when")
+
+        if "priority" in edge:
+            priority = edge.get("priority")
+            if not isinstance(priority, int) or isinstance(priority, bool) or priority < 1:
+                errors.append(f"{label}.priority must be a positive integer")
+
+        if valid_source and valid_target:
+            record = (index, edge, guard_reads)
+            validated_edges.append(record)
+            outgoing[source].append(record)
+            incoming[target].append(record)
+            adjacency[source].add(target)
+
+    routing_nodes: set[str] = set()
+    for node_id, node in nodes.items():
+        edges = outgoing[node_id]
+        if node.get("kind") == "terminal":
+            if edges:
+                errors.append(f"terminal node {node_id} must not have outgoing edges")
+        elif not edges:
+            errors.append(f"non-terminal node {node_id} has no outgoing edge")
+
+        guarded = [record for record in edges if "when" in record[1]]
+        defaults = [record for record in edges if record[1].get("default") is True]
+        requires_routing = node.get("kind") == "router" or bool(guarded) or bool(defaults)
+        if requires_routing:
+            routing_nodes.add(node_id)
+            if len(edges) < 2:
+                errors.append(f"routing node {node_id} needs at least two outgoing edges")
+            if len(defaults) != 1:
+                errors.append(f"routing node {node_id} needs exactly one default edge")
+            for _, edge, _ in edges:
+                if edge.get("default") is not True and "when" not in edge:
+                    errors.append(f"routing edge {node_id} -> {edge.get('to')} needs a condition")
+
+            conditions: dict[str, int] = {}
+            for index, edge, guard_reads in guarded:
+                guard = edge.get("when")
+                if isinstance(guard, str) and guard.strip():
+                    normalized = " ".join(guard.split())
+                    if normalized in conditions:
+                        errors.append(
+                            f"edges[{index}].when duplicates edges[{conditions[normalized]}].when"
+                        )
+                    else:
+                        conditions[normalized] = index
+                unavailable = sorted(
+                    set(guard_reads) - (node_reads.get(node_id, set()) | node_writes.get(node_id, set()))
+                )
+                if unavailable:
+                    errors.append(
+                        f"edges[{index}].reads is unavailable to source node {node_id}: "
+                        f"{', '.join(unavailable)}"
+                    )
+
+            if len(guarded) > 1:
+                priorities = [record[1].get("priority") for record in guarded]
+                if not all(
+                    isinstance(priority, int)
+                    and not isinstance(priority, bool)
+                    and priority > 0
+                    for priority in priorities
+                ):
+                    errors.append(
+                        f"routing node {node_id} with multiple guards needs a priority on every guard"
+                    )
+                elif len(set(priorities)) != len(priorities):
+                    errors.append(f"routing node {node_id} guard priorities must be unique")
+
+        if node.get("kind") == "join":
+            input_count = len(incoming[node_id])
+            if input_count < 2:
+                errors.append(f"join node {node_id} needs at least two incoming edges")
+            join = node.get("join")
+            if is_mapping(join) and join.get("strategy") == "quorum":
+                quorum = join.get("quorum")
+                if (
+                    isinstance(quorum, int)
+                    and not isinstance(quorum, bool)
+                    and quorum > input_count
+                ):
+                    errors.append(
+                        f"join node {node_id}.quorum exceeds its {input_count} incoming edges"
+                    )
+
+    reachability_adjacency: dict[str, set[str]] = defaultdict(set)
+    for source, targets in adjacency.items():
+        reachability_adjacency[source].update(targets)
+    virtual_transitions: dict[tuple[str, str], bool] = {}
+
+    def add_virtual_transition(
+        source: str,
+        target: str,
+        *,
+        include_source_writes: bool = False,
+    ) -> None:
+        reachability_adjacency[source].add(target)
+        key = (source, target)
+        if key in virtual_transitions:
+            virtual_transitions[key] = (
+                virtual_transitions[key] and include_source_writes
+            )
+        else:
+            virtual_transitions[key] = include_source_writes
+
+    for node_id, target in failure_targets.items():
+        if not isinstance(target, str) or target not in nodes:
+            errors.append(f"node {node_id}.failure.on_failure must reference a node")
+        elif nodes[target].get("kind") == "join":
+            errors.append(f"node {node_id}.failure.on_failure must not target a join")
+        else:
+            add_virtual_transition(node_id, target)
+
+    parallel_items = document.get("parallel_groups", [])
+    if not is_list(parallel_items):
+        errors.append("parallel_groups must be a list")
+        parallel_items = []
+    seen_parallel: set[str] = set()
+    for index, group in enumerate(parallel_items):
+        label = f"parallel_groups[{index}]"
+        if not is_mapping(group):
+            errors.append(f"{label} must be a mapping")
+            continue
+        group_id = validate_identifier(group.get("id"), f"{label}.id", errors)
+        if group_id is not None:
+            if group_id in seen_parallel:
+                errors.append(f"duplicate parallel group id: {group_id}")
+            seen_parallel.add(group_id)
+
+        branches = string_list(group.get("branches"), f"{label}.branches", errors, min_items=2)
+        if len(set(branches)) != len(branches):
+            errors.append(f"{label}.branches must contain unique node ids")
+        unknown_branches = sorted(set(branches) - nodes.keys())
+        if unknown_branches:
+            errors.append(f"{label} references unknown branches: {', '.join(unknown_branches)}")
+
+        join_id = group.get("join")
+        valid_join = isinstance(join_id, str) and join_id in nodes
+        if not isinstance(join_id, str):
+            errors.append(f"{label}.join must be a node identifier")
+        elif not valid_join or nodes[join_id].get("kind") != "join":
+            errors.append(f"{label}.join must reference a join node")
+
+        branch_paths: dict[str, set[str]] = {}
+        if valid_join:
+            for branch in branches:
+                if branch not in nodes:
+                    continue
+                if join_id not in walk(branch, adjacency):
+                    errors.append(f"parallel branch {branch} cannot reach join {join_id}")
+                    continue
+                branch_paths[branch] = walk_until(branch, join_id, adjacency)
+
+        valid_branches = sorted(branch_paths)
+        for left_index, left in enumerate(valid_branches):
+            for right in valid_branches[left_index + 1 :]:
+                overlap = sorted(branch_paths[left] & branch_paths[right])
+                if overlap:
+                    errors.append(
+                        f"parallel branches {left} and {right} converge before join {join_id}: "
+                        f"{', '.join(overlap)}"
+                    )
+                left_writes = set().union(
+                    *(node_writes.get(node_id, set()) for node_id in branch_paths[left])
+                )
+                right_writes = set().union(
+                    *(node_writes.get(node_id, set()) for node_id in branch_paths[right])
+                )
+                for state_name in sorted(left_writes & right_writes):
+                    merge = state_fields.get(state_name, {}).get("merge")
+                    if merge not in PARALLEL_SAFE_MERGES:
+                        errors.append(
+                            f"parallel group {group_id or index} has conflicting writers for "
+                            f"{state_name} with merge {merge}"
+                        )
+
+        partial_failure = group.get("on_partial_failure")
+        if not isinstance(partial_failure, str) or not partial_failure.strip():
+            errors.append(f"{label}.on_partial_failure must reference a recovery node")
+        elif partial_failure not in nodes:
+            errors.append(f"{label}.on_partial_failure references unknown node: {partial_failure}")
+        elif nodes[partial_failure].get("kind") == "join":
+            errors.append(f"{label}.on_partial_failure must not target a join")
+        else:
+            for branch in branches:
+                if branch in nodes:
+                    add_virtual_transition(branch, partial_failure)
+
+    loop_items = document.get("loops", [])
+    if not is_list(loop_items):
+        errors.append("loops must be a list")
+        loop_items = []
+    declared_loops: list[set[str]] = []
+    loop_read_contracts: list[tuple[str, str, set[str]]] = []
+    loop_ids: set[str] = set()
+    for index, loop in enumerate(loop_items):
+        label = f"loops[{index}]"
+        if not is_mapping(loop):
+            errors.append(f"{label} must be a mapping")
+            continue
+        loop_id = validate_identifier(loop.get("id"), f"{label}.id", errors)
+        if loop_id is not None:
+            if loop_id in loop_ids:
+                errors.append(f"duplicate loop id: {loop_id}")
+            loop_ids.add(loop_id)
+
+        members = string_list(loop.get("nodes"), f"{label}.nodes", errors, min_items=1)
+        member_set = set(members)
+        if len(member_set) != len(members):
+            errors.append(f"{label}.nodes must contain unique node ids")
+        unknown_members = sorted(member_set - nodes.keys())
+        if unknown_members:
+            errors.append(f"{label} references unknown nodes: {', '.join(unknown_members)}")
+        if member_set in declared_loops:
+            errors.append(f"{label}.nodes duplicates another declared loop")
+        declared_loops.append(member_set)
+
+        exit_when = loop.get("exit_when")
+        if not isinstance(exit_when, str) or not exit_when.strip():
+            errors.append(f"{label}.exit_when must be a non-empty string")
+        exit_reads = string_list(loop.get("reads"), f"{label}.reads", errors, min_items=1)
+        unknown_exit_reads = sorted(set(exit_reads) - state_names)
+        if unknown_exit_reads:
+            errors.append(f"{label}.reads references unknown state: {', '.join(unknown_exit_reads)}")
+        if isinstance(exit_when, str):
+            omitted_refs = sorted(set(GUARD_STATE_REF.findall(exit_when)) - set(exit_reads))
+            if omitted_refs:
+                errors.append(
+                    f"{label}.reads omits state referenced by exit_when: {', '.join(omitted_refs)}"
+                )
+        evaluate_after = loop.get("evaluate_after")
+        if not isinstance(evaluate_after, str) or evaluate_after not in member_set:
+            errors.append(f"{label}.evaluate_after must reference a loop member")
+        elif evaluate_after in nodes:
+            loop_read_contracts.append((label, evaluate_after, set(exit_reads)))
+
+        max_iterations = loop.get("max_iterations")
+        timeout = loop.get("timeout")
+        bounded_iterations = (
+            isinstance(max_iterations, int)
+            and not isinstance(max_iterations, bool)
+            and max_iterations > 0
+        )
+        bounded_timeout = isinstance(timeout, str) and bool(timeout.strip())
+        if not bounded_iterations and not bounded_timeout:
+            errors.append(f"{label} needs a positive max_iterations or timeout")
+
+        exhausted = loop.get("on_exhausted")
+        if not isinstance(exhausted, str) or not exhausted.strip():
+            errors.append(f"{label}.on_exhausted must reference a recovery node")
+        elif exhausted not in nodes:
+            errors.append(f"{label}.on_exhausted references unknown node: {exhausted}")
+        elif exhausted in member_set:
+            errors.append(f"{label}.on_exhausted must leave the loop")
+        elif nodes[exhausted].get("kind") == "join":
+            errors.append(f"{label}.on_exhausted must not target a join")
+        else:
+            for member in member_set & nodes.keys():
+                add_virtual_transition(
+                    member,
+                    exhausted,
+                    include_source_writes=True,
+                )
+
+    approval_resume_contracts: dict[str, set[str]] = {}
+    for node_id in approval_nodes:
+        approval = nodes[node_id].get("approval")
+        if not is_mapping(approval):
+            errors.append(f"approval node {node_id} needs an approval mapping")
+            continue
+        decision_state = approval.get("decision_state")
+        if not isinstance(decision_state, str) or decision_state not in state_fields:
+            errors.append(f"approval node {node_id}.decision_state must reference state")
+        else:
+            if decision_state not in node_writes.get(node_id, set()):
+                errors.append(f"approval node {node_id} must write its decision_state")
+            if state_fields[decision_state].get("persist") is not True:
+                errors.append(f"approval node {node_id}.decision_state must persist")
+
+        resume_state = string_list(
+            approval.get("resume_state"),
+            f"approval node {node_id}.resume_state",
+            errors,
+            min_items=1,
+        )
+        approval_resume_contracts[node_id] = set(resume_state)
+        unknown_resume = sorted(set(resume_state) - state_names)
+        if unknown_resume:
+            errors.append(
+                f"approval node {node_id}.resume_state references unknown state: "
+                f"{', '.join(unknown_resume)}"
+            )
+        non_persistent = sorted(
+            state_name
+            for state_name in set(resume_state) & state_names
+            if state_fields[state_name].get("persist") is not True
+        )
+        if non_persistent:
+            errors.append(
+                f"approval node {node_id}.resume_state must persist: {', '.join(non_persistent)}"
+            )
+
+        outgoing_targets = {record[1].get("to") for record in outgoing[node_id]}
+        for key in ("on_rejected", "on_expired"):
+            target = approval.get(key)
+            if not isinstance(target, str) or target not in nodes:
+                errors.append(f"approval node {node_id}.{key} must reference a node")
+            elif target not in outgoing_targets:
+                errors.append(f"approval node {node_id}.{key} needs a matching outgoing edge")
+
+    recovery = document.get("recovery")
+    if not is_mapping(recovery):
+        warnings.append("recovery should define checkpoint_state and failure destinations")
+    else:
+        checkpoint_state = string_list(
+            recovery.get("checkpoint_state"), "recovery.checkpoint_state", errors
+        )
+        unknown_checkpoint = sorted(set(checkpoint_state) - state_names)
+        if unknown_checkpoint:
+            errors.append(
+                "recovery.checkpoint_state references unknown state: "
+                + ", ".join(unknown_checkpoint)
+            )
+        non_persistent = sorted(
+            state_name
+            for state_name in set(checkpoint_state) & state_names
+            if state_fields[state_name].get("persist") is not True
+        )
+        if non_persistent:
+            errors.append(
+                "recovery.checkpoint_state must persist: " + ", ".join(non_persistent)
+            )
+        for key in ("on_unhandled_error", "on_cancel"):
+            target = recovery.get(key)
+            if not isinstance(target, str) or target not in nodes:
+                errors.append(f"recovery.{key} must reference a node")
+            elif nodes[target].get("kind") == "join":
+                errors.append(f"recovery.{key} must not target a join")
+            else:
+                for source, node in nodes.items():
+                    if source != target and node.get("kind") != "terminal":
+                        add_virtual_transition(source, target)
+
+    actual_cycles = cyclic_components(nodes.keys(), reachability_adjacency)
+    for component in actual_cycles:
+        if component not in declared_loops:
+            errors.append(
+                "undeclared or incorrectly declared cycle including recovery paths: "
+                + ", ".join(sorted(component))
+            )
+    for index, declared in enumerate(declared_loops):
+        if declared and declared not in actual_cycles:
+            errors.append(
+                f"loops[{index}].nodes must exactly match a cyclic component: "
+                + ", ".join(sorted(declared))
+            )
+
+    evaluation = document.get("evaluation")
+    if not is_mapping(evaluation):
+        warnings.append("evaluation should define at least one machine-readable check")
+    else:
+        checks = evaluation.get("checks")
+        if not is_list(checks) or not checks:
+            errors.append("evaluation.checks must be a non-empty list")
+        else:
+            for index, check in enumerate(checks):
+                label = f"evaluation.checks[{index}]"
+                if not is_mapping(check):
+                    errors.append(f"{label} must be a mapping")
+                    continue
+                scope = check.get("scope")
+                target = check.get("target")
+                if not isinstance(scope, str) or scope not in EVALUATION_SCOPES:
+                    errors.append(f"{label}.scope is invalid")
+                if not isinstance(target, str) or not target.strip():
+                    errors.append(f"{label}.target must be a non-empty string")
+                elif scope == "graph" and target != graph_id:
+                    errors.append(f"{label}.target must reference graph.id")
+                elif scope == "loop" and target not in loop_ids:
+                    errors.append(f"{label}.target must reference a loop")
+                elif scope in {"node", "route", "join"} and target not in nodes:
+                    errors.append(f"{label}.target must reference a node")
+                elif scope == "route" and target not in routing_nodes:
+                    errors.append(f"{label}.target must reference a routing node")
+                elif scope == "join" and nodes.get(target, {}).get("kind") != "join":
+                    errors.append(f"{label}.target must reference a join node")
+                if not isinstance(check.get("metric"), str) or not check["metric"].strip():
+                    errors.append(f"{label}.metric must be a non-empty string")
+
+    observability = document.get("observability")
+    if not is_mapping(observability):
+        warnings.append("observability should define captured events and redaction")
+    else:
+        capture = string_list(observability.get("capture"), "observability.capture", errors)
+        missing_events = sorted(REQUIRED_EVENTS - set(capture))
+        if missing_events:
+            warnings.append(f"observability.capture omits: {', '.join(missing_events)}")
+        redact_sensitive_state = observability.get("redact_sensitive_state")
+        if not isinstance(redact_sensitive_state, bool):
+            errors.append("observability.redact_sensitive_state must be boolean")
+        elif has_sensitive_state and redact_sensitive_state is not True:
+            errors.append("observability must redact declared sensitive state")
+
+    if entry is not None:
+        reachable = walk(entry, reachability_adjacency)
+        unreachable = sorted(nodes.keys() - reachable)
+        if unreachable:
+            errors.append(f"unreachable nodes: {', '.join(unreachable)}")
+
+        predecessors: dict[str, list[tuple[str, bool]]] = defaultdict(list)
+        for _, edge, _ in validated_edges:
+            source = edge["from"]
+            target = edge["to"]
+            predecessors[target].append((source, True))
+        for (source, target), include_source_writes in virtual_transitions.items():
+            predecessors[target].append((source, include_source_writes))
+
+        available_in = {
+            node_id: set(initial_state) if node_id == entry else set(state_names)
+            for node_id in nodes
         }
-    ]
-    sensitive["observability"]["redact_sensitive_state"] = False
-    sensitive_errors, _ = validate_document(sensitive)
-    if valid_errors:
-        print("[ERROR] self-test valid fixture failed:")
+        max_rounds = max(1, len(nodes) * (len(state_names) + 1))
+        for _ in range(max_rounds):
+            changed = False
+            next_available = {node_id: set(values) for node_id, values in available_in.items()}
+            for node_id, node in nodes.items():
+                if node_id == entry:
+                    candidate = set(initial_state)
+                else:
+                    incoming_availability: list[set[str]] = []
+                    for source, include_source_writes in predecessors[node_id]:
+                        source_state = set(available_in[source])
+                        if include_source_writes:
+                            source_state.update(node_writes.get(source, set()))
+                        incoming_availability.append(source_state)
+
+                    if not incoming_availability:
+                        candidate = set()
+                    elif node.get("kind") == "join" and is_mapping(node.get("join")):
+                        strategy = node["join"].get("strategy")
+                        if strategy == "all":
+                            required_arrivals = len(incoming_availability)
+                        elif strategy == "quorum":
+                            quorum = node["join"].get("quorum")
+                            required_arrivals = (
+                                quorum
+                                if isinstance(quorum, int)
+                                and not isinstance(quorum, bool)
+                                and quorum > 0
+                                else 1
+                            )
+                        else:
+                            required_arrivals = 1
+                        required_writers = len(incoming_availability) - required_arrivals + 1
+                        candidate = {
+                            state_name
+                            for state_name in state_names
+                            if sum(
+                                state_name in values for values in incoming_availability
+                            )
+                            >= required_writers
+                        }
+                    else:
+                        candidate = set.intersection(*incoming_availability)
+
+                if candidate != available_in[node_id]:
+                    next_available[node_id] = candidate
+                    changed = True
+            available_in = next_available
+            if not changed:
+                break
+
+        for node_id in sorted(reachable):
+            unavailable_reads = sorted(node_reads.get(node_id, set()) - available_in[node_id])
+            if unavailable_reads:
+                errors.append(
+                    f"node {node_id}.reads is not definitely available on every path: "
+                    f"{', '.join(unavailable_reads)}"
+                )
+
+        for label, evaluate_after, reads in loop_read_contracts:
+            available_after = available_in[evaluate_after] | node_writes.get(
+                evaluate_after, set()
+            )
+            unavailable_reads = sorted(reads - available_after)
+            if unavailable_reads:
+                errors.append(
+                    f"{label}.reads is not definitely available after {evaluate_after}: "
+                    f"{', '.join(unavailable_reads)}"
+                )
+
+        for node_id, resume_state in approval_resume_contracts.items():
+            unavailable_resume = sorted(resume_state - available_in[node_id])
+            if unavailable_resume:
+                errors.append(
+                    f"approval node {node_id}.resume_state is not definitely available: "
+                    f"{', '.join(unavailable_resume)}"
+                )
+
+    return errors, warnings
+
+
+def run_self_test() -> int:
+    asset_path = Path(__file__).resolve().parent.parent / "assets" / "graph-spec.json"
+    try:
+        valid = json.loads(asset_path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"[ERROR] self-test cannot read template: {exc}")
+        return 1
+
+    valid_errors, valid_warnings = validate_document(valid)
+    if valid_errors or valid_warnings:
+        print("[ERROR] self-test template fixture failed:")
         for message in valid_errors:
-            print(f"  - {message}")
+            print(f"  - error: {message}")
+        for message in valid_warnings:
+            print(f"  - warning: {message}")
         return 1
-    if not invalid_errors:
-        print("[ERROR] self-test invalid fixture unexpectedly passed")
+
+    exhausted_valid = json.loads(json.dumps(valid))
+    exhausted_valid["graph"]["terminals"].append("exhausted")
+    exhausted_valid["nodes"].append(
+        {
+            "id": "exhausted",
+            "kind": "terminal",
+            "purpose": "Record the final loop decision after exhaustion.",
+            "reads": ["review_decision"],
+            "writes": [],
+            "side_effects": [],
+            "idempotent": True,
+            "timeout": "1m",
+            "retry": {"max_attempts": 1},
+        }
+    )
+    exhausted_valid["loops"][0]["on_exhausted"] = "exhausted"
+    exhausted_errors, exhausted_warnings = validate_document(exhausted_valid)
+    if exhausted_errors or exhausted_warnings:
+        print("[ERROR] self-test valid exhaustion fixture failed:")
+        for message in exhausted_errors:
+            print(f"  - error: {message}")
+        for message in exhausted_warnings:
+            print(f"  - warning: {message}")
         return 1
-    if "observability must redact declared sensitive state" not in sensitive_errors:
-        print("[ERROR] self-test sensitive-state fixture unexpectedly passed")
-        return 1
-    print("[OK] validator self-test passed")
+
+    cases: list[tuple[str, dict[str, Any], str]] = []
+
+    missing_target = json.loads(json.dumps(valid))
+    missing_target["edges"][0]["to"] = "missing"
+    cases.append(("missing target", missing_target, "references unknown node"))
+
+    sensitive = json.loads(json.dumps(valid))
+    sensitive["state"][0]["sensitive"] = True
+    sensitive["observability"]["redact_sensitive_state"] = False
+    cases.append(("sensitive state", sensitive, "must redact declared sensitive state"))
+
+    malformed = json.loads(json.dumps(valid))
+    malformed["nodes"][0]["reads"] = [[]]
+    malformed["edges"][0]["from"] = []
+    cases.append(("malformed types", malformed, "must be a node identifier"))
+
+    quorum = json.loads(json.dumps(valid))
+    synthesize = next(node for node in quorum["nodes"] if node["id"] == "synthesize")
+    synthesize["join"] = {"strategy": "quorum", "quorum": 99}
+    cases.append(("impossible quorum", quorum, "quorum exceeds"))
+
+    terminal_drift = json.loads(json.dumps(valid))
+    publish = next(node for node in terminal_drift["nodes"] if node["id"] == "publish")
+    publish["kind"] = "terminal"
+    cases.append(("terminal drift", terminal_drift, "missing from graph.terminals"))
+
+    exhaustion = json.loads(json.dumps(valid))
+    exhaustion["loops"][0]["on_exhausted"] = "missing"
+    cases.append(("unknown exhaustion", exhaustion, "on_exhausted references unknown node"))
+
+    partial_failure = json.loads(json.dumps(valid))
+    partial_failure["parallel_groups"][0]["on_partial_failure"] = "missing"
+    cases.append(
+        (
+            "unknown partial failure",
+            partial_failure,
+            "on_partial_failure references unknown node",
+        )
+    )
+
+    conflict = json.loads(json.dumps(valid))
+    research = next(node for node in conflict["nodes"] if node["id"] == "research")
+    risk = next(node for node in conflict["nodes"] if node["id"] == "risk_assessment")
+    research["writes"].append("proposal")
+    risk["writes"].append("proposal")
+    proposal = next(field for field in conflict["state"] if field["name"] == "proposal")
+    proposal["writers"].append("research")
+    proposal["writers"].append("risk_assessment")
+    cases.append(("parallel writer conflict", conflict, "conflicting writers for proposal"))
+
+    unknown_guard = json.loads(json.dumps(valid))
+    review_edge = next(edge for edge in unknown_guard["edges"] if edge.get("when"))
+    review_edge["when"] = 'ghost.status == "approved"'
+    review_edge["reads"] = ["ghost"]
+    cases.append(("unknown guard state", unknown_guard, "reads references unknown state"))
+
+    duplicate_guard = json.loads(json.dumps(valid))
+    review_edges = [edge for edge in duplicate_guard["edges"] if edge["from"] == "review"]
+    review_edges[1].pop("default")
+    review_edges[1]["when"] = review_edges[0]["when"]
+    review_edges[1]["reads"] = list(review_edges[0]["reads"])
+    review_edges[0]["priority"] = 1
+    review_edges[1]["priority"] = 2
+    cases.append(("duplicate guard", duplicate_guard, ".when duplicates"))
+
+    writer_drift = json.loads(json.dumps(valid))
+    proposal = next(field for field in writer_drift["state"] if field["name"] == "proposal")
+    proposal["writers"].remove("revise")
+    cases.append(("writer drift", writer_drift, "writers omits actual writers"))
+
+    approval_contract = json.loads(json.dumps(valid))
+    approval = next(node for node in approval_contract["nodes"] if node["id"] == "approval")
+    approval.pop("approval")
+    cases.append(("approval contract", approval_contract, "needs an approval mapping"))
+
+    recovery_contract = json.loads(json.dumps(valid))
+    recovery_contract["recovery"]["on_cancel"] = "missing"
+    cases.append(("recovery contract", recovery_contract, "recovery.on_cancel must reference"))
+
+    evaluation_contract = json.loads(json.dumps(valid))
+    evaluation_contract["evaluation"]["checks"][0]["target"] = "publish"
+    cases.append(
+        (
+            "evaluation contract",
+            evaluation_contract,
+            "target must reference a routing node",
+        )
+    )
+
+    recovery_cycle = json.loads(json.dumps(valid))
+    recovery_cycle["recovery"]["on_unhandled_error"] = "intake"
+    cases.append(
+        (
+            "recovery cycle",
+            recovery_cycle,
+            "cycle including recovery paths",
+        )
+    )
+
+    unavailable_state = json.loads(json.dumps(valid))
+    failed = next(node for node in unavailable_state["nodes"] if node["id"] == "failed")
+    failed["reads"] = ["proposal"]
+    cases.append(
+        (
+            "unavailable failure state",
+            unavailable_state,
+            "not definitely available on every path",
+        )
+    )
+
+    missing_initial_contract = json.loads(json.dumps(valid))
+    missing_initial_contract["state"][0].pop("initial")
+    cases.append(
+        (
+            "initial state contract",
+            missing_initial_contract,
+            ".initial must be boolean",
+        )
+    )
+
+    missing_failure_contract = json.loads(json.dumps(valid))
+    intake = next(node for node in missing_failure_contract["nodes"] if node["id"] == "intake")
+    intake.pop("failure")
+    cases.append(
+        (
+            "node failure contract",
+            missing_failure_contract,
+            "needs a failure mapping",
+        )
+    )
+
+    unavailable_loop_read = json.loads(json.dumps(valid))
+    unavailable_loop_read["loops"][0]["reads"] = ["approval_decision"]
+    unavailable_loop_read["loops"][0]["exit_when"] = (
+        'approval_decision.status == "approved"'
+    )
+    cases.append(
+        (
+            "unavailable loop read",
+            unavailable_loop_read,
+            "is not definitely available after review",
+        )
+    )
+
+    unavailable_resume_state = json.loads(json.dumps(valid))
+    approval = next(
+        node for node in unavailable_resume_state["nodes"] if node["id"] == "approval"
+    )
+    approval["approval"]["resume_state"].append("approval_decision")
+    cases.append(
+        (
+            "unavailable approval resume state",
+            unavailable_resume_state,
+            "resume_state is not definitely available",
+        )
+    )
+
+    padded_loop = json.loads(json.dumps(valid))
+    padded_loop["loops"][0]["nodes"].append("approval")
+    padded_loop["loops"][0]["evaluate_after"] = "approval"
+    padded_loop["loops"][0]["reads"] = ["approval_decision"]
+    padded_loop["loops"][0]["exit_when"] = (
+        'approval_decision.status == "approved"'
+    )
+    cases.append(
+        (
+            "padded loop membership",
+            padded_loop,
+            "nodes must exactly match a cyclic component",
+        )
+    )
+
+    for name, fixture, expected in cases:
+        try:
+            case_errors, _ = validate_document(fixture)
+        except Exception as exc:  # pragma: no cover - this is the behavior under test
+            print(f"[ERROR] self-test {name} crashed: {exc}")
+            return 1
+        if not any(expected in message for message in case_errors):
+            print(f"[ERROR] self-test {name} missed expected error: {expected}")
+            for message in case_errors:
+                print(f"  - {message}")
+            return 1
+
+    print(f"[OK] validator self-test passed ({len(cases)} invalid fixtures)")
     return 0
 
 


### PR DESCRIPTION
## Summary
Add a framework-neutral skill for designing, transforming, reviewing, and evolving reliable workflow graphs, together with a machine-readable Graph Spec and strict validator.

## Changes
- Add guidance for graph suitability, state and node contracts, routing, joins, bounded loops, approvals, recovery, side effects, observability, and evaluation
- Add a reusable Graph Spec template with explicit state ownership, availability, failure destinations, approval resume state, recovery routes, and evaluation checks
- Add a defensive standard-library validator covering references, routing, concurrency, quorum, reachability, recovery cycles, and cross-path state availability
- Add built-in positive coverage and 21 invalid fixtures for previously identified failure modes

## Motivation
- Make workflow graphs reviewable engineering contracts instead of decorative diagrams
- Catch unsafe concurrency, unbounded recovery, invalid routing, and unavailable state before mapping a design to a runtime

## Testing
- `python3 skills/design-workflow-graphs/scripts/validate_graph_spec.py --self-test`
- `python3 skills/design-workflow-graphs/scripts/validate_graph_spec.py --strict skills/design-workflow-graphs/assets/graph-spec.json`
- Skill structure and metadata validation
- `cd web && npm run lint`
- `cd web && npm run build`