### PR TITLE
feat: add executable Atlas Cloud image skill

### DIFF
--- a/skills/atlas-cloud-image-generator/README.md
+++ b/skills/atlas-cloud-image-generator/README.md
@@ -1,0 +1,36 @@
+# Atlas Cloud Image Generator
+
+`atlas-cloud-image-generator` is an executable agent skill for Atlas Cloud text-to-image requests.
+
+It provides:
+
+- schema-aware validation for `google/nano-banana-pro/text-to-image`
+- preview-first request inspection
+- one generation POST per execution
+- bounded prediction polling
+- optional, workspace-confined result download
+- dependency-free execution on Node.js 20 or newer
+
+## Preview
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A clean editorial illustration of a solar-powered city" \
+  --aspect 16:9 \
+  --resolution 2k
+```
+
+## Execute
+
+Set `ATLASCLOUD_API_KEY` or create the local auth file described in `references/config-schema.md`, then add `--execute`:
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A clean editorial illustration of a solar-powered city" \
+  --aspect 16:9 \
+  --resolution 2k \
+  --output output/solar-city.png \
+  --execute
+```
+
+The script submits once to `POST /api/v1/model/generateImage`. It never retries that POST. When the API returns an asynchronous prediction, it performs bounded `GET /api/v1/model/prediction/{id}` reads until the task completes, fails, or reaches the polling limit.

--- a/skills/atlas-cloud-image-generator/SKILL.md
+++ b/skills/atlas-cloud-image-generator/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: atlas-cloud-image-generator
+description: Generate images through Atlas Cloud with schema-aware validation, preview-first execution, bounded prediction polling, and safe local output handling.
+metadata:
+  name: Atlas Cloud Image Generator
+  description: Generate images through Atlas Cloud with validated parameters and bounded polling.
+  author: binyangzhu000-sudo
+  created: 2026-08-21T16:23:48Z
+---
+
+# Atlas Cloud Image Generator
+
+Generate text-to-image assets through Atlas Cloud's asynchronous image API. The bundled executor validates the current working set, previews requests by default, submits at most one generation request per execution, and polls only that prediction.
+
+## Use This Skill For
+
+- text-to-image requests through Atlas Cloud
+- Nano Banana Pro image generation
+- aspect ratio, resolution, and output format selection
+- safe download of a completed result into the current workspace
+- inspecting a request before any billable generation is submitted
+
+Do not use this skill for image editing, reference-image composition, video generation, or undocumented model parameters. Those workflows require their own live model schema checks.
+
+## Workflow
+
+1. Read [references/capability-matrix.md](references/capability-matrix.md) before choosing parameters.
+2. Convert the user's request into one compact prompt with subject, style, composition, environment, and material constraints.
+3. Preview the exact payload with `scripts/generate-image.mjs`.
+4. Confirm that authentication and output handling follow [references/auth-and-safety.md](references/auth-and-safety.md).
+5. Add `--execute` only when the user clearly wants a live generation.
+6. If a prediction ID is returned, poll that ID only. Never repeat the generation POST automatically.
+
+## Quick Start
+
+Preview without making an API request:
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A studio product photo of a ceramic mug on a white background" \
+  --aspect 4:3 \
+  --resolution 2k
+```
+
+Execute one request and save the first completed output:
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A studio product photo of a ceramic mug on a white background" \
+  --aspect 4:3 \
+  --resolution 2k \
+  --output output/mug.png \
+  --execute
+```
+
+The default model is `google/nano-banana-pro/text-to-image`. See [references/request-examples.md](references/request-examples.md) for the complete command surface.
+
+## Execution Rules
+
+- Preview mode is the default and does not require an API key.
+- Live execution reads `ATLASCLOUD_API_KEY` or the local auth file documented in [references/config-schema.md](references/config-schema.md).
+- A live run performs one `POST /api/v1/model/generateImage`. Submission is never retried automatically.
+- Prediction reads use bounded backoff against `GET /api/v1/model/prediction/{id}`.
+- `--output` must resolve inside the current workspace and must not already exist.
+- Result URLs are redacted in console output and downloaded without forwarding the API key.
+- An ambiguous submit timeout is not evidence that the request failed. Keep the prediction ID when available and inspect that task instead of resubmitting.
+
+## Stop Conditions
+
+Stop before execution when:
+
+- the requested capability is absent from the current model schema
+- authentication is missing or malformed
+- the output path escapes the workspace or already exists
+- the user has not authorized a live, potentially billable request
+- a submit response is ambiguous and repeating it could create a duplicate charge

--- a/skills/atlas-cloud-image-generator/agents/openai.yaml
+++ b/skills/atlas-cloud-image-generator/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Atlas Cloud Image Generator"
+  short_description: "Generate images through Atlas Cloud"
+  default_prompt: "Use $atlas-cloud-image-generator to validate an Atlas Cloud text-to-image request, preview the payload, and execute exactly one generation request only when the user authorizes it."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/atlas-cloud-image-generator/references/auth-and-safety.md
+++ b/skills/atlas-cloud-image-generator/references/auth-and-safety.md
@@ -1,0 +1,26 @@
+# Authentication and Safety
+
+## Authentication
+
+Live execution checks credentials in this order:
+
+1. `ATLASCLOUD_API_KEY`
+2. `api_key` in `~/.config/flc1125/skills/atlas-cloud-image-generator/auth.json`
+
+The optional auth file may also set `base_url`. Preview mode does not read or require a credential.
+
+Never put a real API key in a command argument, repository file, prompt, or log. The executor sends the key only in the Atlas Cloud API `Authorization` header and does not forward it when downloading a completed output.
+
+## Billable Request Boundary
+
+`--execute` submits one generation POST. The executor never retries that POST, including after a timeout or connection error. Automatic retries can create duplicate billable jobs.
+
+After a successful submission, only prediction GET requests are repeated. Polling is bounded and uses increasing delays capped at five seconds.
+
+## Output Boundary
+
+- Output download is optional and requires `--output`.
+- The destination must resolve inside the current workspace.
+- Existing files are never overwritten.
+- Provider-returned signed query strings are not printed.
+- The Atlas Cloud API key is never attached to the result download request.

--- a/skills/atlas-cloud-image-generator/references/capability-matrix.md
+++ b/skills/atlas-cloud-image-generator/references/capability-matrix.md
@@ -1,0 +1,29 @@
+# Capability Matrix
+
+This skill intentionally keeps one verified executable model in its default working set.
+
+Schema checked: 2026-08-22 against the model catalog entry and linked OpenAPI schema returned by `GET https://api.atlascloud.ai/api/v1/models`.
+
+| Model | Workflow | Required | Optional working set |
+|---|---|---|---|
+| `google/nano-banana-pro/text-to-image` | text-to-image | `model`, `prompt` | `aspect_ratio`, `resolution`, `output_format`, `enable_web_search` |
+
+## Valid Values
+
+Aspect ratios:
+
+`1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
+
+Resolutions:
+
+`1k`, `2k`, `4k`
+
+Output formats:
+
+`default`, `png`, `jpeg`
+
+## Excluded Fields
+
+The executor does not expose `enable_sync_mode`, `enable_base64_output`, or `media_resolution`. They are unnecessary for the text-only asynchronous workflow supported here.
+
+Do not pass reference images or editing fields to this model. Fetch the live schema again before adding another model or capability because model IDs and accepted parameters may change.

--- a/skills/atlas-cloud-image-generator/references/config-schema.md
+++ b/skills/atlas-cloud-image-generator/references/config-schema.md
@@ -1,0 +1,26 @@
+# Local Auth Configuration
+
+Default path:
+
+`~/.config/flc1125/skills/atlas-cloud-image-generator/auth.json`
+
+Minimal shape:
+
+```json
+{
+  "version": 1,
+  "api_key": "replace_with_your_atlas_cloud_api_key"
+}
+```
+
+Optional custom API origin:
+
+```json
+{
+  "version": 1,
+  "api_key": "replace_with_your_atlas_cloud_api_key",
+  "base_url": "https://api.atlascloud.ai"
+}
+```
+
+Keep this file outside the repository and restrict it to the current user. Prefer `ATLASCLOUD_API_KEY` when the surrounding environment already manages secrets securely.

--- a/skills/atlas-cloud-image-generator/references/request-examples.md
+++ b/skills/atlas-cloud-image-generator/references/request-examples.md
@@ -1,0 +1,57 @@
+# Request Examples
+
+All commands run from the repository or installed plugin root.
+
+## Preview The Default Request
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A geometric poster of a mountain observatory at night"
+```
+
+## Preview A Wide 4K PNG Request
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "An isometric cutaway of a sustainable research station" \
+  --aspect 16:9 \
+  --resolution 4k \
+  --output-format png
+```
+
+## Execute And Download
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A precise botanical plate of alpine wildflowers" \
+  --aspect 3:4 \
+  --resolution 2k \
+  --output-format png \
+  --output output/alpine-wildflowers.png \
+  --execute
+```
+
+## Optional Web Search Grounding
+
+```bash
+node skills/atlas-cloud-image-generator/scripts/generate-image.mjs \
+  --prompt "A current infographic about the phases of the Moon this month" \
+  --web-search
+```
+
+## Full Flag Surface
+
+```text
+--prompt <text>          Required generation prompt
+--model <id>             Verified model override
+--aspect <ratio>         Default: 1:1
+--resolution <value>     Default: 1k
+--output-format <value>  default | png | jpeg
+--web-search             Enable model web search grounding
+--output <path>          Download first completed output inside the workspace
+--base-url <url>         Override API origin
+--auth-file <path>       Override local auth file
+--poll-attempts <n>      Prediction GET limit, 1-60 (default: 24)
+--execute                 Submit exactly one live generation request
+--help                    Show usage
+```

--- a/skills/atlas-cloud-image-generator/scripts/generate-image.mjs
+++ b/skills/atlas-cloud-image-generator/scripts/generate-image.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_BASE_URL = 'https://api.atlascloud.ai';
+const DEFAULT_MODEL = 'google/nano-banana-pro/text-to-image';
+const DEFAULT_AUTH_PATH = '~/.config/flc1125/skills/atlas-cloud-image-generator/auth.json';
+const DEFAULT_POLL_ATTEMPTS = 24;
+const SUPPORTED_MODELS = new Set([DEFAULT_MODEL]);
+const ASPECT_RATIOS = new Set(['1:1', '3:2', '2:3', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9']);
+const RESOLUTIONS = new Set(['1k', '2k', '4k']);
+const OUTPUT_FORMATS = new Set(['default', 'png', 'jpeg']);
+const VALUE_FLAGS = new Set([
+  'prompt',
+  'model',
+  'aspect',
+  'resolution',
+  'output-format',
+  'output',
+  'base-url',
+  'auth-file',
+  'poll-attempts',
+]);
+const BOOLEAN_FLAGS = new Set(['execute', 'web-search', 'help']);
+const WORKSPACE_ROOT = fs.realpathSync.native(process.cwd());
+
+function printUsage() {
+  console.log([
+    'Generate an image through Atlas Cloud.',
+    '',
+    'Usage:',
+    '  node skills/atlas-cloud-image-generator/scripts/generate-image.mjs --prompt "..." [options]',
+    '',
+    'Options:',
+    '  --prompt <text>          Required generation prompt',
+    `  --model <id>             Model (default: ${DEFAULT_MODEL})`,
+    '  --aspect <ratio>         Aspect ratio (default: 1:1)',
+    '  --resolution <value>     1k | 2k | 4k (default: 1k)',
+    '  --output-format <value>  default | png | jpeg (default: default)',
+    '  --web-search             Enable web search grounding',
+    '  --output <path>          Save first output inside the current workspace',
+    `  --base-url <url>         API origin (default: ${DEFAULT_BASE_URL})`,
+    `  --auth-file <path>       Auth file (default: ${DEFAULT_AUTH_PATH})`,
+    `  --poll-attempts <n>      Prediction GET limit, 1-60 (default: ${DEFAULT_POLL_ATTEMPTS})`,
+    '  --execute                Submit exactly one generation request',
+    '  --help                   Show this help',
+    '',
+    'Preview mode is the default.',
+  ].join('\n'));
+}
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    if (BOOLEAN_FLAGS.has(key)) {
+      args[key] = true;
+      continue;
+    }
+    if (!VALUE_FLAGS.has(key)) {
+      throw new Error(`Unknown option: --${key}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Expected a value after --${key}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+
+  return args;
+}
+
+function requireNonEmpty(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Missing required argument: --${label}`);
+  }
+  return value.trim();
+}
+
+function parsePollAttempts(value) {
+  if (value === undefined) {
+    return DEFAULT_POLL_ATTEMPTS;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error('--poll-attempts must be an integer from 1 to 60');
+  }
+  const parsed = Number(value);
+  if (parsed < 1 || parsed > 60) {
+    throw new Error('--poll-attempts must be an integer from 1 to 60');
+  }
+  return parsed;
+}
+
+function validateChoice(value, choices, label) {
+  if (!choices.has(value)) {
+    throw new Error(`Invalid --${label} value: ${value}. Use: ${[...choices].join(', ')}`);
+  }
+}
+
+function expandPath(inputPath) {
+  if (inputPath.startsWith('~/')) {
+    return path.join(os.homedir(), inputPath.slice(2));
+  }
+  return path.resolve(inputPath);
+}
+
+function resolveOutputPath(outputPath) {
+  const resolved = path.resolve(outputPath);
+  let existingParent = path.dirname(resolved);
+
+  while (!fs.existsSync(existingParent)) {
+    const nextParent = path.dirname(existingParent);
+    if (nextParent === existingParent) {
+      throw new Error(`Could not resolve output parent: ${resolved}`);
+    }
+    existingParent = nextParent;
+  }
+
+  const realParent = fs.realpathSync.native(existingParent);
+  const realTarget = path.resolve(realParent, path.relative(existingParent, resolved));
+  const relative = path.relative(WORKSPACE_ROOT, realTarget);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Output path must stay inside the current workspace: ${WORKSPACE_ROOT}`);
+  }
+  if (fs.existsSync(realTarget)) {
+    throw new Error(`Refusing to overwrite existing file: ${realTarget}`);
+  }
+  return realTarget;
+}
+
+function loadAuth(authPath) {
+  if (!fs.existsSync(authPath)) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(authPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Invalid JSON in auth file ${authPath}: ${error.message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Auth file must contain a JSON object: ${authPath}`);
+  }
+  return parsed;
+}
+
+function normalizeBaseUrl(baseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`Invalid --base-url: ${baseUrl}`);
+  }
+  if (parsed.protocol !== 'https:' && parsed.hostname !== '127.0.0.1' && parsed.hostname !== 'localhost') {
+    throw new Error('API base URL must use HTTPS');
+  }
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+function buildRequest(args) {
+  const model = args.model || DEFAULT_MODEL;
+  const aspectRatio = args.aspect || '1:1';
+  const resolution = (args.resolution || '1k').toLowerCase();
+  const outputFormat = args['output-format'] || 'default';
+
+  validateChoice(model, SUPPORTED_MODELS, 'model');
+  validateChoice(aspectRatio, ASPECT_RATIOS, 'aspect');
+  validateChoice(resolution, RESOLUTIONS, 'resolution');
+  validateChoice(outputFormat, OUTPUT_FORMATS, 'output-format');
+
+  const payload = {
+    model,
+    prompt: requireNonEmpty(args.prompt, 'prompt'),
+    aspect_ratio: aspectRatio,
+    resolution,
+    output_format: outputFormat,
+  };
+  if (args['web-search']) {
+    payload.enable_web_search = true;
+  }
+  return payload;
+}
+
+function unwrap(body) {
+  if (body && typeof body === 'object' && body.data && typeof body.data === 'object' && !Array.isArray(body.data)) {
+    return body.data;
+  }
+  return body;
+}
+
+function safeError(body, fallback) {
+  const candidate = unwrap(body);
+  for (const value of [candidate?.message, candidate?.error?.message, candidate?.error, body?.message]) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim().slice(0, 400);
+    }
+  }
+  return fallback;
+}
+
+async function readJson(response, operation) {
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`${operation} returned non-JSON data with HTTP ${response.status}`);
+    }
+  }
+  if (!response.ok) {
+    throw new Error(`${operation} failed with HTTP ${response.status}: ${safeError(body, response.statusText)}`);
+  }
+  return unwrap(body);
+}
+
+async function submitOnce(baseUrl, apiKey, payload) {
+  let response;
+  try {
+    response = await fetch(`${baseUrl}/api/v1/model/generateImage`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (error) {
+    throw new Error(`Generation submission did not return a response; it was not retried: ${error.message}`);
+  }
+  return readJson(response, 'Generation submission');
+}
+
+function predictionId(body) {
+  const id = body?.id ?? body?.prediction_id ?? body?.request_id;
+  return id === undefined || id === null ? null : String(id);
+}
+
+function predictionStatus(body) {
+  return String(body?.status || '').toLowerCase();
+}
+
+function outputUrls(body) {
+  const candidates = [body?.outputs, body?.output, body?.images];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      return candidate
+        .map((item) => (typeof item === 'string' ? item : item?.url))
+        .filter((item) => typeof item === 'string' && item.length > 0);
+    }
+    if (typeof candidate === 'string') {
+      return [candidate];
+    }
+  }
+  return [];
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function pollPrediction(baseUrl, apiKey, id, maxAttempts) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (attempt > 1) {
+      await sleep(Math.min(5_000, 1_000 * 2 ** (attempt - 2)));
+    }
+
+    const response = await fetch(
+      `${baseUrl}/api/v1/model/prediction/${encodeURIComponent(id)}`,
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    const prediction = await readJson(response, 'Prediction read');
+    const status = predictionStatus(prediction);
+    if (['completed', 'succeeded', 'success'].includes(status)) {
+      return prediction;
+    }
+    if (['failed', 'canceled', 'cancelled'].includes(status)) {
+      throw new Error(`Prediction ${id} ended with status ${status}: ${safeError(prediction, 'no failure message')}`);
+    }
+  }
+  throw new Error(`Prediction ${id} did not finish within ${maxAttempts} GET attempts`);
+}
+
+function redactUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return '<redacted>';
+  }
+}
+
+async function downloadResult(resultUrl, destination) {
+  const response = await fetch(resultUrl, {
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Result download failed with HTTP ${response.status}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, bytes, { flag: 'wx' });
+}
+
+async function execute(args, baseUrl, auth, payload, outputPath, maxAttempts) {
+  const apiKey = process.env.ATLASCLOUD_API_KEY || auth?.api_key;
+  if (!apiKey || typeof apiKey !== 'string') {
+    throw new Error('Missing ATLASCLOUD_API_KEY and auth file api_key');
+  }
+
+  const submitted = await submitOnce(baseUrl, apiKey, payload);
+  const id = predictionId(submitted);
+  let completed = submitted;
+  const initialStatus = predictionStatus(submitted);
+  if (!['completed', 'succeeded', 'success'].includes(initialStatus)) {
+    if (!id) {
+      throw new Error('Generation submission did not return a prediction ID');
+    }
+    console.error(`Submitted prediction ${id}; polling with bounded GET requests.`);
+    completed = await pollPrediction(baseUrl, apiKey, id, maxAttempts);
+  }
+
+  const urls = outputUrls(completed);
+  if (urls.length === 0) {
+    throw new Error(`Prediction ${id || '<synchronous>'} completed without an output URL`);
+  }
+  if (outputPath) {
+    await downloadResult(urls[0], outputPath);
+  }
+
+  console.log(JSON.stringify({
+    mode: 'execute',
+    prediction_id: id,
+    status: predictionStatus(completed),
+    outputs: urls.map(redactUrl),
+    output_path: outputPath,
+  }, null, 2));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const payload = buildRequest(args);
+  const maxAttempts = parsePollAttempts(args['poll-attempts']);
+  const authPath = expandPath(args['auth-file'] || DEFAULT_AUTH_PATH);
+  const auth = loadAuth(authPath);
+  const baseUrl = normalizeBaseUrl(args['base-url'] || auth?.base_url || DEFAULT_BASE_URL);
+  const outputPath = args.output ? resolveOutputPath(args.output) : null;
+
+  if (!args.execute) {
+    console.log(JSON.stringify({
+      mode: 'preview',
+      endpoint: `${baseUrl}/api/v1/model/generateImage`,
+      payload,
+      output_path: outputPath,
+      poll_attempts: maxAttempts,
+    }, null, 2));
+    return;
+  }
+
+  await execute(args, baseUrl, auth, payload, outputPath, maxAttempts);
+}
+
+main().catch((error) => {
+  console.error(`[ERROR] ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add an executable `atlas-cloud-image-generator` skill for Atlas Cloud text-to-image requests
- validate the documented Nano Banana Pro model parameters and preview payloads before execution
- submit at most one generation POST, then use bounded prediction GET polling
- keep optional downloads inside the workspace, refuse overwrites, and redact signed result URLs

## Validation

- `node --check skills/atlas-cloud-image-generator/scripts/generate-image.mjs`
- preview and invalid-model CLI checks
- local mock API: 1 submission POST, 2 prediction GETs, 1 unauthenticated asset download
- `cd web && npm run lint`
- `cd web && npm run build`
- live Atlas Cloud smoke reached the billing gate and returned HTTP 402, so no paid prediction was created
