### PR TITLE
feat(github-renovate-prs): add go-build-tools preset

### DIFF
--- a/skills/github-renovate-prs/README.md
+++ b/skills/github-renovate-prs/README.md
@@ -47,6 +47,7 @@ When no repository is specified, the skill scans this preset set:
 - `flc1125/go-cron`
 - `flc1125/go-gitlab-webhook`
 - `flc1125/go-yuque`
+- `flc1125/go-build-tools`
 
 ## How It Works
 

--- a/skills/github-renovate-prs/SKILL.md
+++ b/skills/github-renovate-prs/SKILL.md
@@ -54,6 +54,7 @@ When the user does not specify a target repository, use this fixed preset set:
 - `flc1125/go-cron`
 - `flc1125/go-gitlab-webhook`
 - `flc1125/go-yuque`
+- `flc1125/go-build-tools`
 
 Do not ask for confirmation before scanning this preset set. Scanning is read-only.
 


### PR DESCRIPTION
## Summary
Add flc1125/go-build-tools to the default repository set scanned by the GitHub Renovate PRs skill.

## Changes
- Include flc1125/go-build-tools in the skill default preset
- Keep the README repository list in sync

## Motivation
- Cover Renovate updates for go-build-tools during preset scans

## Testing
- quick_validate.py
- git diff --check