### PR TITLE
feat(eli5): add picture-first explainer skill

### DIFF
--- a/skills/eli5/README.md
+++ b/skills/eli5/README.md
@@ -1,0 +1,54 @@
+# ELI5
+
+Create a picture-first explanation of a topic for someone with no prior knowledge.
+
+The skill produces a self-contained HTML artifact with large visuals, short labels, one concrete example, and a concise takeaway.
+
+## Install
+
+```bash
+npx skills add https://skills.flc.io --skill eli5
+```
+
+If the custom skill source is temporarily unavailable, install from GitHub:
+
+```bash
+npx skills add https://github.com/flc1125/skills --skill eli5
+```
+
+## Usage
+
+Invoke the skill with a topic:
+
+```text
+Use $eli5 to explain how DNS works.
+```
+
+It is intended for explicit ELI5 requests and picture-first explainers. Ordinary concise explanations do not need this skill.
+
+## What This Version Adds
+
+This repository keeps the upstream idea of explaining a topic with big pictures and very few words, while adding:
+
+- tool-agnostic topic handling instead of relying on Claude-specific argument substitution
+- a standalone HTML output contract with no packages, build step, or network access
+- guidance for accurate analogies, responsive layout, and accessibility
+- clearer activation boundaries and fallback behavior for other requested output formats
+
+## Structure
+
+```text
+eli5/
+├── SKILL.md
+├── README.md
+└── agents/
+    └── openai.yaml
+```
+
+## Source Attribution
+
+This skill is an adapted implementation inspired by the following upstream source:
+
+- Author/Repository: `anthropics/claude-plugins-community`
+- Upstream path: `eli5/skills/eli5/SKILL.md`
+- URL: <https://github.com/anthropics/claude-plugins-community/blob/main/eli5/skills/eli5/SKILL.md>

--- a/skills/eli5/SKILL.md
+++ b/skills/eli5/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   name: ELI5
   description: Turn a topic into a picture-first HTML explainer for someone with no prior knowledge.
   author: Flc
-  created: 2026-08-26T01:01:38Z
+  created: 2026-08-26T01:45:03Z
 ---
 
 # ELI5

--- a/skills/eli5/SKILL.md
+++ b/skills/eli5/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: eli5
+description: Create a dead-simple visual explanation of a topic as a self-contained HTML artifact. Use when the user says ELI5, asks to explain something like they are five, or wants a picture-first explanation with very few words; do not use for ordinary concise explanations that do not ask for this format.
+metadata:
+  name: ELI5
+  description: Turn a topic into a picture-first HTML explainer for someone with no prior knowledge.
+  author: Flc
+  created: 2026-08-26T01:01:38Z
+---
+
+# ELI5
+
+Explain the topic from the user's request as if the reader knows nothing about it.
+
+Create one self-contained HTML artifact with big visuals and very few words. Prefer a simple diagram, pictograms, arrows, labels, and one concrete example over paragraphs of explanation.
+
+## Outcome
+
+The reader should be able to glance at the artifact and understand:
+
+- what the thing is
+- how its main parts or steps relate
+- one useful mental model or everyday analogy
+- the single most important takeaway
+
+## Rules
+
+- Use plain, respectful language. Simplify the topic, not the reader.
+- Lead with the visual explanation; keep supporting text short.
+- Focus on one core idea. Omit secondary details unless they prevent a false understanding.
+- Use familiar examples and define unavoidable technical terms in place.
+- Keep analogies accurate. Briefly label where an analogy stops matching reality when that boundary matters.
+- Prefer meaningful CSS shapes, inline SVG, emoji, or simple icons that render without external assets.
+- Make the artifact responsive, readable, and accessible with semantic HTML, sufficient contrast, and useful text alternatives.
+- Keep everything in one HTML file with embedded CSS and JavaScript. Do not require packages, a build step, or network access.
+- Do not ask follow-up questions when the topic is already clear. If it is broad, choose the smallest useful mental model and state that scope in the artifact.
+- If the user explicitly requests another output medium, keep the same picture-first, few-words teaching style in that medium.
+
+## Suggested Shape
+
+Use only the sections the topic needs:
+
+1. a short title and one-line meaning
+2. a large visual showing the core relationship or flow
+3. one everyday example
+4. a one-sentence recap
+
+Do not turn the artifact into a textbook page, slide deck, or dense dashboard.

--- a/skills/eli5/agents/openai.yaml
+++ b/skills/eli5/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ELI5"
+  short_description: "Picture-first explainers with very few words"
+  default_prompt: "Use $eli5 to turn this topic into a dead-simple, picture-first HTML explainer for someone with no prior knowledge."


### PR DESCRIPTION
## Summary
Add an installable ELI5 skill that turns a topic into a self-contained, picture-first HTML explainer for readers with no prior knowledge.

## Changes
- Define focused activation rules and a visual-first output contract
- Add guidance for accurate analogies, responsive layout, accessibility, and dependency-free HTML
- Add Codex UI metadata and usage documentation with upstream source attribution
- Align skill creation metadata with the first Git commit

## Motivation
- Provide a cross-runtime adaptation of the Anthropic community ELI5 skill without relying on Claude-specific argument substitution

## Testing
- Skill structure validation
- `npm run generate:skills-data`
- `npm run lint`
- `npm run build`
- `git diff --check`