### PR TITLE
feat(web): expose marketplace tools through WebMCP

### DIFF
--- a/docs/engineering-guide.md
+++ b/docs/engineering-guide.md
@@ -100,6 +100,17 @@ The marketplace stores public view and copy totals in Upstash Redis. Counts begi
 
 The public `GET /api/stats` endpoint returns all skill totals in one response and is cached at the CDN for 60 seconds. `POST /api/stats/:slug` accepts a `view` or `copy` interaction, validates the skill slug, applies the deduplication window, and returns the updated total. The UI hides the counters when Redis is not configured instead of showing misleading zeroes.
 
+## 8. WebMCP Progressive Enhancement
+
+The marketplace exposes four browser-native WebMCP tools when the current browser implements `document.modelContext.registerTool()`:
+
+*   `search_skills`: Search skill names and descriptions or list the newest skills.
+*   `get_skill_detail`: Load the complete metadata and Markdown content for a skill.
+*   `get_install_command`: Return the individual `npx skills add` command for a skill.
+*   `open_skill`: Open a skill detail modal in the current browser tab.
+
+WebMCP is a progressive enhancement. The registration component performs feature detection in the browser and renders nothing. Unsupported and older browsers skip registration while retaining the complete marketplace UI and API behavior. Registration uses an `AbortSignal` so tools are automatically removed when the component unmounts, and registration failures do not block page rendering.
+
 ---
 
 *For further technical questions, please refer to the [Next.js Documentation](https://nextjs.org/docs).*

--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -9,7 +9,9 @@ import { RepositoryInstallPanel } from './RepositoryInstallPanel';
 import { SkillCard } from './SkillCard';
 import { SkillModal } from './SkillModal';
 import { SortSelect } from './SortSelect';
+import { WebMcpTools } from './WebMcpTools';
 import { trackEvent } from '@/lib/gtag';
+import { filterSkillsByQuery } from '@/lib/skill-catalog';
 import { formatInteractionCount } from '@/lib/utils';
 import { DEFAULT_SORT_KEY, SORT_OPTIONS, getSkillComparator, isStatsSortKey, normalizeSortKey } from '@/lib/sorting';
 import type { SortKey } from '@/lib/sorting';
@@ -157,19 +159,9 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
   }, [hasMounted, selectedSkillSlug]);
 
   const orderedSkills = useMemo(() => {
-    const normalizedSearch = search.toLowerCase();
-
-    return initialSkills
-      .filter((skill) => {
-        const displayName = skill.metadata?.name ?? skill.name;
-        const displayDescription = skill.metadata?.description ?? skill.description;
-
-        return (
-          displayName.toLowerCase().includes(normalizedSearch) ||
-          displayDescription.toLowerCase().includes(normalizedSearch)
-        );
-      })
-      .sort(getSkillComparator(sortKey, statsSnapshot));
+    return filterSkillsByQuery(initialSkills, search).sort(
+      getSkillComparator(sortKey, statsSnapshot)
+    );
   }, [initialSkills, search, sortKey, statsSnapshot]);
 
   const totalSkills = initialSkills.length;
@@ -217,11 +209,11 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
     return () => window.clearTimeout(timeout);
   }, [orderedSkills.length, search]);
 
-  const handleCardClick = (skillMeta: SkillMetadata) => {
+  const openSkill = useCallback((skillMeta: SkillMetadata) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('skill', skillMeta.slug);
     window.history.pushState(null, '', `${pathname}?${params.toString()}`);
-  };
+  }, [pathname, searchParams]);
 
   const handleSortChange = (key: SortKey) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -377,7 +369,7 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
                 skill={skill}
                 stats={statsSnapshot.enabled ? statsSnapshot.skills[skill.slug] : undefined}
                 position={index + 1}
-                onClick={handleCardClick}
+                onClick={openSkill}
               />
             ))}
           </AnimatePresence>
@@ -420,6 +412,7 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
         onStatsChange={handleStatsChange}
         onClose={handleCloseModal}
       />
+      <WebMcpTools skills={initialSkills} onOpenSkill={openSkill} />
     </motion.div>
     </MotionConfig>
   );

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -10,6 +10,7 @@ import { X, Terminal, Copy, Check, ExternalLink, CalendarDays, Eye, Files, Arrow
 import { formatInteractionCount, formatSkillPublishedAt } from '@/lib/utils';
 import { trackEvent } from '@/lib/gtag';
 import { recordSkillInteraction } from '@/lib/skill-stats-client';
+import { getSkillInstallCommand } from '@/lib/install-methods';
 import type { SkillStats } from '@/lib/skill-stats';
 
 interface SkillModalProps {
@@ -134,7 +135,7 @@ export function SkillModal({
   }, [displayName, isOpen, onStatsChange, skill]);
 
   const command = skill
-    ? `npx skills add https://skills.flc.io --skill ${skill.installName}`
+    ? getSkillInstallCommand(skill.installName)
     : '';
   const sourceUrl = skill
     ? `https://github.com/flc1125/skills/blob/main/skills/${skill.path}`

--- a/web/src/components/WebMcpTools.tsx
+++ b/web/src/components/WebMcpTools.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  filterSkillsByQuery,
+  getSkillDisplayDescription,
+  getSkillDisplayName,
+} from '@/lib/skill-catalog';
+import { getSkillInstallCommand } from '@/lib/install-methods';
+import { DEFAULT_SORT_KEY, getSkillComparator } from '@/lib/sorting';
+import type { Skill, SkillMetadata } from '@/lib/skills';
+
+interface WebMcpToolsProps {
+  skills: SkillMetadata[];
+  onOpenSkill: (skill: SkillMetadata) => void;
+}
+
+interface WebMcpExecuteOptions {
+  signal: AbortSignal;
+}
+
+interface WebMcpTool {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (
+    input: Record<string, unknown>,
+    options: WebMcpExecuteOptions
+  ) => Promise<unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+  };
+}
+
+interface WebMcpModelContext {
+  registerTool: (
+    tool: WebMcpTool,
+    options?: { signal?: AbortSignal }
+  ) => Promise<void>;
+}
+
+type WebMcpDocument = Document & {
+  modelContext?: WebMcpModelContext;
+};
+
+const DEFAULT_SEARCH_LIMIT = 10;
+const MAX_SEARCH_LIMIT = 25;
+
+function getModelContext(): WebMcpModelContext | null {
+  const modelContext = (document as WebMcpDocument).modelContext;
+
+  return modelContext && typeof modelContext.registerTool === 'function'
+    ? modelContext
+    : null;
+}
+
+function readStringInput(
+  input: Record<string, unknown>,
+  key: string,
+  options: { required?: boolean } = {}
+): string {
+  const value = input[key];
+
+  if (value == null && !options.required) {
+    return '';
+  }
+
+  if (typeof value !== 'string' || (options.required && !value.trim())) {
+    throw new Error(`${key} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function readSearchLimit(input: Record<string, unknown>): number {
+  const value = input.limit;
+
+  if (value == null) {
+    return DEFAULT_SEARCH_LIMIT;
+  }
+
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MAX_SEARCH_LIMIT
+  ) {
+    throw new Error(`limit must be an integer between 1 and ${MAX_SEARCH_LIMIT}.`);
+  }
+
+  return value;
+}
+
+function findSkillBySlug(skills: SkillMetadata[], slug: string): SkillMetadata {
+  const skill = skills.find((entry) => entry.slug === slug);
+
+  if (!skill) {
+    throw new Error(`Unknown skill slug: ${slug}`);
+  }
+
+  return skill;
+}
+
+async function waitForUiUpdate(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    throw signal.reason;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let frame = 0;
+    const handleAbort = () => {
+      window.cancelAnimationFrame(frame);
+      reject(signal.reason);
+    };
+
+    signal.addEventListener('abort', handleAbort, { once: true });
+    frame = window.requestAnimationFrame(() => {
+      signal.removeEventListener('abort', handleAbort);
+      resolve();
+    });
+  });
+}
+
+export function WebMcpTools({ skills, onOpenSkill }: WebMcpToolsProps) {
+  const skillsRef = useRef(skills);
+  const onOpenSkillRef = useRef(onOpenSkill);
+
+  useEffect(() => {
+    skillsRef.current = skills;
+  }, [skills]);
+
+  useEffect(() => {
+    onOpenSkillRef.current = onOpenSkill;
+  }, [onOpenSkill]);
+
+  useEffect(() => {
+    const modelContext = getModelContext();
+
+    if (!modelContext) {
+      return;
+    }
+
+    const registrationController = new AbortController();
+    const tools: WebMcpTool[] = [
+      {
+        name: 'search_skills',
+        title: 'Search Skills',
+        description:
+          "Search Flc's Skills by display name or description. An empty query lists the newest available skills.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Text to match against skill display names and descriptions.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: MAX_SEARCH_LIMIT,
+              default: DEFAULT_SEARCH_LIMIT,
+              description: `Maximum number of results to return, from 1 to ${MAX_SEARCH_LIMIT}.`,
+            },
+          },
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+          untrustedContentHint: true,
+        },
+        async execute(input) {
+          const query = readStringInput(input, 'query');
+          const limit = readSearchLimit(input);
+          const matches = filterSkillsByQuery(skillsRef.current, query).sort(
+            getSkillComparator(DEFAULT_SORT_KEY)
+          );
+
+          return {
+            query,
+            total: matches.length,
+            results: matches.slice(0, limit).map((skill) => ({
+              slug: skill.slug,
+              name: getSkillDisplayName(skill),
+              description: getSkillDisplayDescription(skill),
+              installName: skill.installName,
+              fileCount: skill.fileCount,
+            })),
+          };
+        },
+      },
+      {
+        name: 'get_skill_detail',
+        title: 'Get Skill Detail',
+        description:
+          "Get the full metadata and Markdown content for one skill from Flc's Skills.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            slug: {
+              type: 'string',
+              minLength: 1,
+              description: 'The exact skill slug returned by search_skills.',
+            },
+          },
+          required: ['slug'],
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+          untrustedContentHint: true,
+        },
+        async execute(input, { signal }) {
+          const slug = readStringInput(input, 'slug', { required: true });
+          findSkillBySlug(skillsRef.current, slug);
+
+          const response = await fetch(`/api/skills/${encodeURIComponent(slug)}`, {
+            signal,
+          });
+
+          if (!response.ok) {
+            throw new Error(
+              response.status === 404
+                ? `Unknown skill slug: ${slug}`
+                : `Unable to load skill detail (${response.status}).`
+            );
+          }
+
+          return (await response.json()) as Skill;
+        },
+      },
+      {
+        name: 'get_install_command',
+        title: 'Get Install Command',
+        description:
+          "Get the individual npx installation command for one skill from Flc's Skills.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            slug: {
+              type: 'string',
+              minLength: 1,
+              description: 'The exact skill slug returned by search_skills.',
+            },
+          },
+          required: ['slug'],
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
+        async execute(input) {
+          const slug = readStringInput(input, 'slug', { required: true });
+          const skill = findSkillBySlug(skillsRef.current, slug);
+
+          return {
+            slug: skill.slug,
+            name: getSkillDisplayName(skill),
+            installName: skill.installName,
+            command: getSkillInstallCommand(skill.installName),
+          };
+        },
+      },
+      {
+        name: 'open_skill',
+        title: 'Open Skill',
+        description:
+          "Open one skill's detail modal in the current Flc's Skills browser tab.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            slug: {
+              type: 'string',
+              minLength: 1,
+              description: 'The exact skill slug returned by search_skills.',
+            },
+          },
+          required: ['slug'],
+          additionalProperties: false,
+        },
+        async execute(input, { signal }) {
+          const slug = readStringInput(input, 'slug', { required: true });
+          const skill = findSkillBySlug(skillsRef.current, slug);
+
+          onOpenSkillRef.current(skill);
+          await waitForUiUpdate(signal);
+
+          return {
+            opened: true,
+            slug: skill.slug,
+            name: getSkillDisplayName(skill),
+            url: window.location.href,
+          };
+        },
+      },
+    ];
+
+    const registerTools = async () => {
+      try {
+        for (const tool of tools) {
+          await modelContext.registerTool(tool, {
+            signal: registrationController.signal,
+          });
+        }
+      } catch (error) {
+        if (!registrationController.signal.aborted) {
+          registrationController.abort();
+
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('WebMCP tools could not be registered:', error);
+          }
+        }
+      }
+    };
+
+    void registerTools();
+
+    return () => registrationController.abort();
+  }, []);
+
+  return null;
+}

--- a/web/src/lib/install-methods.ts
+++ b/web/src/lib/install-methods.ts
@@ -12,6 +12,12 @@ export type InstallMethod = {
   commands: InstallCommand[];
 };
 
+const SKILLS_REGISTRY_URL = 'https://skills.flc.io';
+
+export function getSkillInstallCommand(installName: string): string {
+  return `npx skills add ${SKILLS_REGISTRY_URL} --skill ${installName}`;
+}
+
 export const repositoryInstallMethods: InstallMethod[] = [
   {
     id: 'codex',

--- a/web/src/lib/skill-catalog.ts
+++ b/web/src/lib/skill-catalog.ts
@@ -1,0 +1,30 @@
+import type { SkillMetadata } from './skills';
+
+export function getSkillDisplayName(skill: SkillMetadata): string {
+  return skill.metadata?.name ?? skill.name;
+}
+
+export function getSkillDisplayDescription(skill: SkillMetadata): string {
+  return skill.metadata?.description ?? skill.description;
+}
+
+export function filterSkillsByQuery(
+  skills: SkillMetadata[],
+  query: string
+): SkillMetadata[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return [...skills];
+  }
+
+  return skills.filter((skill) => {
+    const displayName = getSkillDisplayName(skill);
+    const displayDescription = getSkillDisplayDescription(skill);
+
+    return (
+      displayName.toLowerCase().includes(normalizedQuery) ||
+      displayDescription.toLowerCase().includes(normalizedQuery)
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Add progressive WebMCP support to the skills marketplace so compatible browser agents can discover, inspect, install, and open skills without relying on DOM automation.

## Changes
- Register search_skills, get_skill_detail, get_install_command, and open_skill through document.modelContext
- Feature-detect WebMCP and use AbortSignal-based cleanup so unsupported browsers retain the existing marketplace behavior
- Share search, navigation, and install-command logic between the UI and WebMCP tools, with maintenance guidance in the engineering docs

## Motivation
- Give browser agents a stable, structured interface to the marketplace while preserving full compatibility for browsers without WebMCP

## Testing
- npm run lint
- npx tsc --noEmit
- npm run build
- git diff --check

## Notes
- There are no visual UI changes
- End-to-end tool invocation requires a WebMCP-enabled Chromium build