### PR TITLE
fix(web): resolve WebMCP runtime regressions

### DIFF
--- a/web/src/components/Marketplace.tsx
+++ b/web/src/components/Marketplace.tsx
@@ -91,6 +91,7 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
     ? initialSkills.find((skill) => skill.slug === selectedSkillSlug) ?? null
     : null;
   const isModalOpen = hasMounted && selectedSkillSlug !== null;
+  const publishedAtReference = hasMounted ? new Date() : null;
 
   // Reset detail state when the selected slug changes or clears, using the
   // render-time adjustment pattern instead of an effect.
@@ -369,6 +370,7 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
                 skill={skill}
                 stats={statsSnapshot.enabled ? statsSnapshot.skills[skill.slug] : undefined}
                 position={index + 1}
+                publishedAtReference={publishedAtReference}
                 onClick={openSkill}
               />
             ))}
@@ -404,6 +406,7 @@ export function Marketplace({ initialSkills, initialStats }: MarketplaceProps) {
         isOpen={isModalOpen}
         isLoading={isLoadingSkill}
         error={skillLoadError}
+        publishedAtReference={publishedAtReference}
         stats={
           statsSnapshot.enabled && selectedSkillSlug
             ? statsSnapshot.skills[selectedSkillSlug]

--- a/web/src/components/SkillCard.tsx
+++ b/web/src/components/SkillCard.tsx
@@ -12,10 +12,17 @@ interface SkillCardProps {
   skill: SkillMetadata;
   stats?: SkillStats;
   position: number;
+  publishedAtReference: Date | null;
   onClick: (skill: SkillMetadata) => void;
 }
 
-export function SkillCard({ skill, stats, position, onClick }: SkillCardProps) {
+export function SkillCard({
+  skill,
+  stats,
+  position,
+  publishedAtReference,
+  onClick,
+}: SkillCardProps) {
   const cardRef = useRef<HTMLButtonElement | null>(null);
   const hasTrackedImpression = useRef(false);
   const spotlightX = useMotionValue(0);
@@ -23,7 +30,10 @@ export function SkillCard({ skill, stats, position, onClick }: SkillCardProps) {
   const spotlight = useMotionTemplate`radial-gradient(220px circle at ${spotlightX}px ${spotlightY}px, color-mix(in srgb, var(--accent) 7%, transparent), transparent 72%)`;
   const displayName = skill.metadata?.name ?? skill.name;
   const displayDescription = skill.metadata?.description ?? skill.description;
-  const publishedAt = formatSkillPublishedAt(skill.metadata?.created);
+  const publishedAt = formatSkillPublishedAt(
+    skill.metadata?.created,
+    publishedAtReference
+  );
 
   useEffect(() => {
     const element = cardRef.current;

--- a/web/src/components/SkillModal.tsx
+++ b/web/src/components/SkillModal.tsx
@@ -19,6 +19,7 @@ interface SkillModalProps {
   isOpen: boolean;
   isLoading: boolean;
   error: string | null;
+  publishedAtReference: Date | null;
   stats?: SkillStats;
   onStatsChange: (slug: string, stats: SkillStats) => void;
   onClose: () => void;
@@ -74,6 +75,7 @@ export function SkillModal({
   isOpen,
   isLoading,
   error,
+  publishedAtReference,
   stats,
   onStatsChange,
   onClose,
@@ -83,7 +85,10 @@ export function SkillModal({
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
   const displayName = skill?.metadata?.name ?? skill?.name ?? fallbackName ?? 'Loading skill';
-  const publishedAt = formatSkillPublishedAt(skill?.metadata?.created);
+  const publishedAt = formatSkillPublishedAt(
+    skill?.metadata?.created,
+    publishedAtReference
+  );
   const fileCountLabel = skill ? `${skill.fileCount} ${skill.fileCount === 1 ? 'file' : 'files'}` : null;
 
   useEffect(() => {

--- a/web/src/components/WebMcpTools.tsx
+++ b/web/src/components/WebMcpTools.tsx
@@ -16,7 +16,7 @@ interface WebMcpToolsProps {
 }
 
 interface WebMcpExecuteOptions {
-  signal: AbortSignal;
+  signal?: AbortSignal;
 }
 
 interface WebMcpTool {
@@ -26,7 +26,7 @@ interface WebMcpTool {
   inputSchema: Record<string, unknown>;
   execute: (
     input: Record<string, unknown>,
-    options: WebMcpExecuteOptions
+    options?: WebMcpExecuteOptions
   ) => Promise<unknown>;
   annotations?: {
     readOnlyHint?: boolean;
@@ -103,21 +103,25 @@ function findSkillBySlug(skills: SkillMetadata[], slug: string): SkillMetadata {
   return skill;
 }
 
-async function waitForUiUpdate(signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    throw signal.reason;
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+}
+
+async function waitForUiUpdate(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    throw getAbortReason(signal);
   }
 
   await new Promise<void>((resolve, reject) => {
     let frame = 0;
     const handleAbort = () => {
       window.cancelAnimationFrame(frame);
-      reject(signal.reason);
+      reject(signal ? getAbortReason(signal) : undefined);
     };
 
-    signal.addEventListener('abort', handleAbort, { once: true });
+    signal?.addEventListener('abort', handleAbort, { once: true });
     frame = window.requestAnimationFrame(() => {
-      signal.removeEventListener('abort', handleAbort);
+      signal?.removeEventListener('abort', handleAbort);
       resolve();
     });
   });
@@ -211,12 +215,12 @@ export function WebMcpTools({ skills, onOpenSkill }: WebMcpToolsProps) {
           readOnlyHint: true,
           untrustedContentHint: true,
         },
-        async execute(input, { signal }) {
+        async execute(input, options) {
           const slug = readStringInput(input, 'slug', { required: true });
           findSkillBySlug(skillsRef.current, slug);
 
           const response = await fetch(`/api/skills/${encodeURIComponent(slug)}`, {
-            signal,
+            signal: options?.signal,
           });
 
           if (!response.ok) {
@@ -279,12 +283,12 @@ export function WebMcpTools({ skills, onOpenSkill }: WebMcpToolsProps) {
           required: ['slug'],
           additionalProperties: false,
         },
-        async execute(input, { signal }) {
+        async execute(input, options) {
           const slug = readStringInput(input, 'slug', { required: true });
           const skill = findSkillBySlug(skillsRef.current, slug);
 
           onOpenSkillRef.current(skill);
-          await waitForUiUpdate(signal);
+          await waitForUiUpdate(options?.signal);
 
           return {
             opened: true,

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -18,23 +18,30 @@ export function parseSkillMetadataDate(value?: string | null): Date | null {
   }
 
   const [, year, month, day, hour, minute, second] = match;
-  const date = new Date(
+  const date = new Date(Date.UTC(
     Number(year),
     Number(month) - 1,
     Number(day),
     Number(hour),
     Number(minute),
     Number(second)
-  );
+  ));
 
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-export function formatSkillPublishedAt(value?: string | null, now = new Date()): string | null {
+export function formatSkillPublishedAt(
+  value?: string | null,
+  now: Date | null = new Date()
+): string | null {
   const date = parseSkillMetadataDate(value);
 
   if (!date) {
     return null;
+  }
+
+  if (!now) {
+    return formatSkillDate(date);
   }
 
   const diffMs = now.getTime() - date.getTime();
@@ -86,9 +93,9 @@ function isYesterday(date: Date, now: Date): boolean {
 }
 
 function formatSkillDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getUTCDate()}`.padStart(2, '0');
 
   return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
## Summary
Fix runtime issues found while validating the marketplace WebMCP integration after deployment.

## Changes
- Accept missing WebMCP execution options and cancellation signals so tool calls remain compatible across runtimes
- Render deterministic UTC publication dates during SSR and hydration, then switch to relative dates after mount
- Preserve the existing no-op fallback for browsers without `document.modelContext`

## Motivation
- `open_skill` updated the page but failed when the runtime omitted `signal`
- Time- and timezone-dependent publication labels caused a React hydration mismatch in production
- Follow-up to #177

## Testing
- `cd web && npm run lint`
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`
- Validated the local production build in the browser with no console errors
- Called `open_skill` through WebMCP and confirmed the tool succeeded, updated the URL, and opened the skill modal
